### PR TITLE
Pep8 formatting and linter warning fixes

### DIFF
--- a/pcpfm/Acquisition.py
+++ b/pcpfm/Acquisition.py
@@ -1,11 +1,11 @@
-'''
+"""
 This module implements the Acquisition object which is a set of data collected from a sample.
 
-A sample in this case could mean a biologically-derived sample or a blank or any other unit that 
+A sample in this case could mean a biologically-derived sample or a blank or any other unit that
 is analyzed for analysis.
 
 Each analytical replicate is therefore its own acquisition.
-'''
+"""
 
 import os
 import numpy as np
@@ -31,22 +31,22 @@ class Acquisition(Sample):
         mzml_filepath=None,
         ionization_mode=None,
         has_ms2=None,
-        experiment=None
+        experiment=None,
     ):
-        
+
         super().__init__(
-            experiment = '',
-            registry = {
+            experiment="",
+            registry={
                 "input_file": source_filepath,
                 "name": name,
                 "sample_id": name,
-                "list_retention_time": None
+                "list_retention_time": None,
             },
-            mode = ionization_mode,
-            sample_type = '',
-            input_file = source_filepath,
-            name = name,
-            id = name,
+            mode=ionization_mode,
+            sample_type="",
+            input_file=source_filepath,
+            name=name,
+            id=name,
         )
         self.experiment = experiment
 
@@ -54,14 +54,14 @@ class Acquisition(Sample):
         self.raw_filepath = raw_filepath
         self.mzml_filepath = mzml_filepath
 
-        #lazily_evaluated
+        # lazily_evaluated
         self.__ionization_mode = ionization_mode
         self.__has_ms2 = has_ms2
 
     @property
     def source_filepath(self):
         return self.input_file
-    
+
     @staticmethod
     def load_acquisition(acquisition_data, experiment):
         """
@@ -81,7 +81,7 @@ class Acquisition(Sample):
             mzml_filepath=acquisition_data["mzml_filepath"],
             ionization_mode=acquisition_data["_Acquisition__ionization_mode"],
             has_ms2=acquisition_data["_Acquisition__has_ms2"],
-            experiment=experiment
+            experiment=experiment,
         )
 
     @staticmethod
@@ -104,7 +104,7 @@ class Acquisition(Sample):
             mzml_filepath=None,
             ionization_mode=None,
             has_ms2=None,
-            experiment=experiment
+            experiment=experiment,
         )
 
     @property
@@ -124,7 +124,7 @@ class Acquisition(Sample):
                     self.__ionization_mode = "neg"
                     self.mode = self.__ionization_mode
                     return self.__ionization_mode
-            except:
+            except BaseException:
                 return self.__ionization_mode
         return self.__ionization_mode
 
@@ -135,7 +135,9 @@ class Acquisition(Sample):
 
         :return: a JSON-friendly dictionary for serialization during experiment saving and loading
         """
-        return recursive_encoder({k: v for k, v in self.__dict__.items() if k != 'experiment'})
+        return recursive_encoder(
+            {k: v for k, v in self.__dict__.items() if k != "experiment"}
+        )
 
     @property
     def has_ms2(self):
@@ -168,7 +170,7 @@ class Acquisition(Sample):
                         if spec.ms_level == 2:
                             self.__has_ms2 = True
                             break
-                except:
+                except BaseException:
                     pass
             if ms_method and self.__has_ms2:
                 self.experiment.MS2_methods.add(ms_method)
@@ -178,10 +180,10 @@ class Acquisition(Sample):
 
     def TIC(self, mz=None, ppm=5, rt=None, rt_tol=2, title=None):
         """
-        This method generates TIC plots for the acquisition. If mz and rt is not provided, 
+        This method generates TIC plots for the acquisition. If mz and rt is not provided,
         this will make the TIC including the entire rt range and all mz values. If mz and rt values
-        are provided as co-indexed lists, then only those regions will be used IN ADDITION to 
-        the entire rt and mz range. These are saved as figures. 
+        are provided as co-indexed lists, then only those regions will be used IN ADDITION to
+        the entire rt and mz range. These are saved as figures.
 
         Args:
             mz (list, optional): mz values to limit the TIC calculation to. Defaults to None.
@@ -192,7 +194,7 @@ class Acquisition(Sample):
 
         Returns:
             str: path to the TIC plot
-        """        
+        """
         if mz is None:
             mz = []
         if rt is None:
@@ -289,4 +291,3 @@ class Acquisition(Sample):
                             passed_filter and must_include == values_to_filter
                         )
         return passed_filter
-    

--- a/pcpfm/EmpCpds.py
+++ b/pcpfm/EmpCpds.py
@@ -1,6 +1,6 @@
-'''
+"""
 This module is concerned with the construction of EmpCpds and their annotation.
-'''
+"""
 
 import json
 import os
@@ -24,10 +24,12 @@ from .utils import (
     extract_CD_csv,
 )
 
+
 class EmpCpds:
     """
     This object is largely a warpper around the dict_empcpds returned from Khipu.
     """
+
     def __init__(self, dict_empcpds, experiment, moniker):
         """
         the empCpds object is a wrapper around dict_empcpds that will associate the dict_empcpds
@@ -58,16 +60,20 @@ class EmpCpds:
 
         Returns:
             dict: ms2_id to ms2_spetra dictionary.
-        """        
+        """
         if self.__ms2_spectra is None:
             ms2_spectra = {}
             for khipu in self.dict_empcpds.values():
                 if "MS2_Spectra" in khipu:
                     for spectrum in khipu["MS2_Spectra"]:
                         if spectrum["precursor_ion_id"] not in ms2_spectra:
-                            ms2_spectra[spectrum["precursor_ion_id"]] = [MS2Spectrum.from_embedding(spectrum)]
+                            ms2_spectra[spectrum["precursor_ion_id"]] = [
+                                MS2Spectrum.from_embedding(spectrum)
+                            ]
                         else:
-                            ms2_spectra[spectrum["precursor_ion_id"]].append(MS2Spectrum.from_embedding(spectrum))
+                            ms2_spectra[spectrum["precursor_ion_id"]].append(
+                                MS2Spectrum.from_embedding(spectrum)
+                            )
             self.__ms2_spectra = ms2_spectra
         return self.__ms2_spectra
 
@@ -113,23 +119,23 @@ class EmpCpds:
 
     def create_annotation_table(self, comprehensive_output=False):
         """
-        This flattens the empcpd annotations into a dataframe summarizing the annotation on a 
+        This flattens the empcpd annotations into a dataframe summarizing the annotation on a
         per-feature level.
-        
+
         This is for the generation of outputs.
 
         Returns:
             dataframe: annotation table
         """
 
-        #ion_relation_lookup = {}
-        #for kp_id, kp in self.dict_empcpds.items():
+        # ion_relation_lookup = {}
+        # for kp_id, kp in self.dict_empcpds.items():
         #    for ms1_peak in kp['MS1_pseudo_Spectra']:
-                
+
         feature_lookup = {}
         for kp_id, kp in self.dict_empcpds.items():
             for ms1_peak in kp["MS1_pseudo_Spectra"]:
-                feature_lookup[ms1_peak['id']] = ms1_peak
+                feature_lookup[ms1_peak["id"]] = ms1_peak
 
         annotation_table = []
         for kp_id, khipu in self.dict_empcpds.items():
@@ -138,12 +144,14 @@ class EmpCpds:
                     annotation_entry = feature_lookup[feature]
                 else:
                     annotation_entry = {}
-                #MS1 annots
+                # MS1 annots
                 l1b_annots = khipu.get("Level_1b", [])
                 for l1b_annot in l1b_annots:
                     l1b_annot_entry = {k: v for k, v in annotation_entry.items()}
                     l1b_annot_entry.update({"feature": feature, "level": "1b"})
-                    l1b_annot_entry.update({"name": l1b_annot[0], "source": l1b_annot[1]})
+                    l1b_annot_entry.update(
+                        {"name": l1b_annot[0], "source": l1b_annot[1]}
+                    )
                     annotation_table.append(l1b_annot_entry)
                 l4_annots = khipu.get("Level_4", [])
                 for l4_annot in l4_annots:
@@ -151,31 +159,33 @@ class EmpCpds:
                     l4_annot_entry.update({"feature": feature, "level": "4"})
                     l4_annot_entry.update(l4_annot)
                     annotation_table.append(l4_annot_entry)
-                #MS2 annots
+                # MS2 annots
                 for ms2_spectrum in khipu.get("MS2_Spectra", []):
                     for annotation in ms2_spectrum["annotations"]:
                         annotation_level = annotation["annotation_level"]
-                        
+
                         # Start with a copy of the base feature info
                         ms2_annotation = {k: v for k, v in annotation_entry.items()}
-                        
+
                         # CORRECTED: Use .update() to add new keys instead of overwriting
-                        ms2_annotation.update({"feature": feature, "level": annotation_level})
-                        
+                        ms2_annotation.update(
+                            {"feature": feature, "level": annotation_level}
+                        )
+
                         # Now, add the specific annotation details
                         ms2_annotation.update(annotation)
-                        
+
                         annotation_table.append(ms2_annotation)
         return pd.DataFrame(annotation_table)
-    
+
     def __update_ms2(self):
         """
         This method will iterate through all the ms2 spectra in the ms2 property and maps them
-        back to the actual khipu objects. 
+        back to the actual khipu objects.
 
-        This is not elegant, but it works. 
+        This is not elegant, but it works.
 
-        This needs to be called whenever the MS2 annotations are updated before saving the 
+        This needs to be called whenever the MS2 annotations are updated before saving the
         empcpd object.
         """
         print("Updating MS2")
@@ -190,7 +200,7 @@ class EmpCpds:
 
     def update_annotations(self, update_ms2=False):
         """
-        This method iterates through all khipus and updates the relevant annotation fields. 
+        This method iterates through all khipus and updates the relevant annotation fields.
 
         Args:
             update_ms2 (bool): if True, update the MS2 annotations, default is False.
@@ -198,11 +208,11 @@ class EmpCpds:
         if update_ms2:
             self.__update_ms2()
         # update other fields in the empCpds:
-        
+
         print("Updating...")
         for kp_id, khipu in self.dict_empcpds.items():
             khipu["identity"] = set()
-            khipu["Database_referred"] = set() 
+            khipu["Database_referred"] = set()
 
             # MS1 only, only Level_1b counts for identity
             if "Level_1b" in khipu:
@@ -219,23 +229,30 @@ class EmpCpds:
             if "MS2_Spectra" in khipu:
                 dedup_annotations = {}
                 for ms2_spectrum in khipu["MS2_Spectra"]:
-                    for annotation in ms2_spectrum['annotations']:
-                        ref_id = annotation['reference_id']
-                        score = round(annotation['msms_score'], 3)
+                    for annotation in ms2_spectrum["annotations"]:
+                        ref_id = annotation["reference_id"]
+                        score = round(annotation["msms_score"], 3)
                         if ref_id in dedup_annotations:
-                            if score > dedup_annotations[ref_id]['score']:
+                            if score > dedup_annotations[ref_id]["score"]:
                                 dedup_annotations[ref_id] = {
-                                    'score': score,
-                                    'annotation': annotation
+                                    "score": score,
+                                    "annotation": annotation,
                                 }
                 for ref_id, ref_id_data in dedup_annotations.items():
-                    khipu['identity'].add((
-                        ref_id,
-                        round(ref_id_data['annotation']['msms_score'], 3),
-                        "matched standard" if ref_id_data['annotation']['annotation_level'] == "Level_1a" else '')
+                    khipu["identity"].add(
+                        (
+                            ref_id,
+                            round(ref_id_data["annotation"]["msms_score"], 3),
+                            "matched standard"
+                            if ref_id_data["annotation"]["annotation_level"]
+                            == "Level_1a"
+                            else "",
                         )
-                    if "primary_db" in ref_id_data['annotation']:
-                        khipu["Database_referred"].add(ref_id_data['annotation']["primary_db"])
+                    )
+                    if "primary_db" in ref_id_data["annotation"]:
+                        khipu["Database_referred"].add(
+                            ref_id_data["annotation"]["primary_db"]
+                        )
                     else:
                         khipu["Database_referred"].add("MS2")
 
@@ -300,7 +317,7 @@ class EmpCpds:
 
     def get_precursor_mz_tree(self, mz_tol):
         """
-        This retrieves or generates the mz tree of all precursor ions for the empCpd MS2 spectra 
+        This retrieves or generates the mz tree of all precursor ions for the empCpd MS2 spectra
         at a given ppm mass tolerance.
 
         Args:
@@ -378,7 +395,7 @@ class EmpCpds:
         The mz tolerance should be in ppm while the rtime tolerance should be provided in rtime units.
 
         Args:
-            
+
         :param query_mz: the mz to search for, defaults to None
         :type query_mz: float, optional
         :param query_rt: the rtime to search for, defaults to None
@@ -417,6 +434,7 @@ class EmpCpds:
 
         :param save_as_monhiker: an alternative moniker to which to save the table. Defaults to None.
         """
+
         def __has_circular_ref(obj):
             from collections.abc import Mapping
 
@@ -424,29 +442,30 @@ class EmpCpds:
             primitives = (str, bytes, int, float, bool, type(None))
 
             def walk(o):
-                if isinstance(o, primitives): 
+                if isinstance(o, primitives):
                     return False
                 oid = id(o)
-                if oid in stack: 
+                if oid in stack:
                     return True
-                if oid in visited: 
+                if oid in visited:
                     return False
-                visited.add(oid); stack.add(oid)
+                visited.add(oid)
+                stack.add(oid)
                 try:
                     if isinstance(o, Mapping):
                         for k, v in o.items():
-                            if walk(k) or walk(v): 
+                            if walk(k) or walk(v):
                                 return True
                     elif isinstance(o, (list, tuple, set)):
                         for x in o:
-                            if walk(x): 
+                            if walk(x):
                                 return True
                     elif hasattr(o, "__dict__"):
-                        if walk(o.__dict__): 
+                        if walk(o.__dict__):
                             return True
                     elif hasattr(o, "__iter__"):
                         for x in o:
-                            if walk(x): 
+                            if walk(x):
                                 return True
                     return False
                 finally:
@@ -454,19 +473,17 @@ class EmpCpds:
 
             return walk(obj)
 
-
-
-
-
         save_as_moniker = self.moniker if save_as_moniker is None else save_as_moniker
         self.experiment.empCpds[save_as_moniker] = os.path.join(
             self.experiment.annotation_subdirectory, save_as_moniker + "_empCpds.json"
         )
 
         print(__has_circular_ref(self.dict_empcpds))
-        
+
         print("Saving...")
-        with open(self.experiment.empCpds[save_as_moniker], "w+", encoding='utf-8') as out_fh:
+        with open(
+            self.experiment.empCpds[save_as_moniker], "w+", encoding="utf-8"
+        ) as out_fh:
             json.dump(self.dict_empcpds, out_fh, indent=4)
         print("Stopping....")
         self.experiment.save()
@@ -481,7 +498,7 @@ class EmpCpds:
             generated
         :return: the empCpds object for the specified moniker
         """
-        with open(experiment.empCpds[moniker], encoding='utf-8') as empcpd_fh:
+        with open(experiment.empCpds[moniker], encoding="utf-8") as empcpd_fh:
             return EmpCpds(json.load(empcpd_fh), experiment, moniker)
 
     def map_ms2(
@@ -492,19 +509,19 @@ class EmpCpds:
         scan_experiment=False,
     ):
         """
-        When MS2 data is acquired, each spectrum will have a retention time and precursor 
-        ion mz. These can be mapped to features in the empCpds before annotation thus 
+        When MS2 data is acquired, each spectrum will have a retention time and precursor
+        ion mz. These can be mapped to features in the empCpds before annotation thus
         limiting any subsequent searches to just the MS2 spectra that appear to represent
-        features that we care about. 
+        features that we care about.
 
         By default this method searches all acquisitions in the experiment for MS2 spectra.
 
         Additional MS2 spectra can be provided as mzml files using the ms2_files param.
 
         Args:
-            mapping_mz_tol (float, optional): mz tolerance for the feature, ion precursor mz 
+            mapping_mz_tol (float, optional): mz tolerance for the feature, ion precursor mz
             match in ppm. Defaults to 5.
-            mapping_rt_tolerance (int, optional): rt tolerance for the feature, ion precursor time match 
+            mapping_rt_tolerance (int, optional): rt tolerance for the feature, ion precursor time match
             in seconds. Defaults to 30.
             ms2_files (str, optional): path to additional ms2 acquisitions. Defaults to None.
             scan_experiment (bool, optional): _description_. Defaults to False.
@@ -522,7 +539,7 @@ class EmpCpds:
             for acq in self.experiment.acquisitions:
                 if acq.has_ms2:
                     mzml_w_ms2.append(acq.mzml_filepath)
-        
+
         matched_ms2_objects = 0
         for ms2_object in lazy_extract_ms2_spectra(mzml_w_ms2):
             used_khipu = set()
@@ -579,12 +596,12 @@ class EmpCpds:
         Returns:
             empCpd: empcpd object
         """
-        charges = [1,2,3] if charges is None else charges
+        charges = [1, 2, 3] if charges is None else charges
         ext_adducts = extended_adducts if ext_adducts is None else ext_adducts
         isotopes = isotope_search_patterns if isotopes is None else isotopes
         default_adducts = {
             "pos": adduct_search_patterns,
-            "neg": adduct_search_patterns_neg
+            "neg": adduct_search_patterns_neg,
         }
         if adducts is None:
             adducts = default_adducts[experiment.ionization_mode]
@@ -623,7 +640,7 @@ class EmpCpds:
                         "neutral_formula_mass": "",
                         "neutral_formula": "",
                         "MS1_pseudo_Spectra": [peak],
-                        "MS2_spectra": []
+                        "MS2_spectra": [],
                     }
         empcpd = EmpCpds(dict_empcpds, experiment, moniker)
         empcpd.save()
@@ -643,7 +660,7 @@ class EmpCpds:
 
         formula_entry_lookup = {}
         for source in annotation_sources:
-            with open(source, encoding='utf-8') as source_fh:
+            with open(source, encoding="utf-8") as source_fh:
                 source_data = json.load(source_fh)
                 for entry in source_data:
                     if entry["neutral_formula"] not in formula_entry_lookup:
@@ -679,20 +696,20 @@ class EmpCpds:
         Level 2 annotations are lower confidence that Level 1 annotations but generated in a similar
         manner, MS2 similarity, but the references spectra are from a public reference database.
 
-        The similarity method can be any method that is provided by matchms. CosineHungarian is the 
+        The similarity method can be any method that is provided by matchms. CosineHungarian is the
         default as it is a mathematically sound formulation of the cosine similarity and fast enough
-        to be practical. 
+        to be practical.
 
         Args:
             msp_files (str): path to directory with ms2 mzml files
             mz_tol (int, optional): mz tolerance in ppm for the precursor_mz_match. Defaults to 5.
-            similarity_method (str, optional): name of the method for the similarity metric. 
+            similarity_method (str, optional): name of the method for the similarity metric.
             Defaults to "CosineHungarian".
-            min_peaks (int, optional): the minimum number of matching peaks between experimental 
+            min_peaks (int, optional): the minimum number of matching peaks between experimental
             and reference specturm. Defaults to 2.
-            score_cutoff (float, optional): the minimum score required for an annotation. 
+            score_cutoff (float, optional): the minimum score required for an annotation.
             Defaults to 0.50.
-        """        
+        """
         match = 0
         msp_files = [msp_files] if isinstance(msp_files, str) else msp_files
         similarity_method = get_similarity_method(similarity_method)
@@ -700,17 +717,18 @@ class EmpCpds:
         for db_ms2 in lazy_extract_ms2_spectra(msp_files, mz_tree=precursor_mz_tree):
             match_tol = db_ms2.prec_mz / 1e6 * mz_tol * 2
             sim_instance = similarity_method(tolerance=match_tol)
-            for possible_match in {x.data for x in precursor_mz_tree.at(db_ms2.prec_mz)}:
+            for possible_match in {
+                x.data for x in precursor_mz_tree.at(db_ms2.prec_mz)
+            }:
                 for exp_ms2 in self.ms2_spectra[possible_match]:
-                    sim_result = sim_instance.pair(db_ms2.matchms_spectrum, exp_ms2.matchms_spectrum)
+                    sim_result = sim_instance.pair(
+                        db_ms2.matchms_spectrum, exp_ms2.matchms_spectrum
+                    )
                     score, n_matches = sim_result.tolist()
                     if score >= score_cutoff and n_matches >= min_peaks:
                         match += 1
                         exp_ms2.annotate(
-                            db_ms2,
-                            score,
-                            n_matches,
-                            annotation_level="Level_2"
+                            db_ms2, score, n_matches, annotation_level="Level_2"
                         )
         self.update_annotations(update_ms2=True)
 
@@ -724,11 +742,11 @@ class EmpCpds:
         score_cutoff=0.80,
     ):
         """
-        Perform l1 annotation on the empcpds. Using CD authentic standard library. 
+        Perform l1 annotation on the empcpds. Using CD authentic standard library.
 
         Args:
             standards_csv (str): path to CD csv export
-            mz_tol (int, optional): mz tolerance to match precursors. Defaults to 5. 
+            mz_tol (int, optional): mz tolerance to match precursors. Defaults to 5.
             Note that this value will be multiplied by 2
             rt_tolerance (int, optional): rt tolerance to match precursors. Defaults to 30.
             similarity_method (str, optional): which matchms similarity method to use. Defaults to "CosineHungarian".
@@ -739,13 +757,21 @@ class EmpCpds:
         precursor_mz_tree = self.get_precursor_mz_tree(2 * mz_tol)
         precursor_rt_tree = self.get_precursor_rt_tree(rt_tolerance)
         i = 0
-        for db_ms2 in extract_CD_csv(standards_csv, self.experiment.ionization_mode, lazy=True):
+        for db_ms2 in extract_CD_csv(
+            standards_csv, self.experiment.ionization_mode, lazy=True
+        ):
             match_tol = db_ms2.prec_mz / 1e6 * mz_tol * 2
             sim_instance = similarity_method(tolerance=match_tol)
-            for possible_match in {x.data for x in precursor_mz_tree.at(db_ms2.prec_mz)}:
-                if possible_match in {x.data for x in precursor_rt_tree.at(db_ms2.rtime)}:
+            for possible_match in {
+                x.data for x in precursor_mz_tree.at(db_ms2.prec_mz)
+            }:
+                if possible_match in {
+                    x.data for x in precursor_rt_tree.at(db_ms2.rtime)
+                }:
                     for exp_ms2 in self.ms2_spectra[possible_match]:
-                        sim_res = sim_instance.pair(db_ms2.matchms_spectrum, exp_ms2.matchms_spectrum)
+                        sim_res = sim_instance.pair(
+                            db_ms2.matchms_spectrum, exp_ms2.matchms_spectrum
+                        )
                         score, n_matches = sim_res.tolist()
                         if score >= score_cutoff and n_matches >= min_peaks:
                             i += 1
@@ -756,14 +782,14 @@ class EmpCpds:
                                 annotation_level="Level_1a",
                             )
         print("Done with L1a")
-        #self.update_annotations(update_ms2=False)
+        # self.update_annotations(update_ms2=False)
 
     def l1b_annotate(self, standards_csv, mz_tol=5, rt_tolerance=10):
         """
-        Level1b annotations are based on mz, rtime tolerance against known standards. 
+        Level1b annotations are based on mz, rtime tolerance against known standards.
 
-        This method takes the exported standard library from mz vault and compares a feature's 
-        rtime and mz to the standard's mz and retention time. 
+        This method takes the exported standard library from mz vault and compares a feature's
+        rtime and mz to the standard's mz and retention time.
 
         Args:
             standards_csv (str): path to mzvault export
@@ -771,7 +797,7 @@ class EmpCpds:
             rt_tolerance (int, optional): rt tolerance in seconds. Defaults to 10.
         """
         for csv in standards_csv:
-            for standard in pd.read_csv(csv).to_dict(orient='records'):
+            for standard in pd.read_csv(csv).to_dict(orient="records"):
                 mz, rtime, cname = [
                     standard[k] for k in ["Confirm Precursor", "RT", "CompoundName"]
                 ]
@@ -782,4 +808,4 @@ class EmpCpds:
                     if "Level_1b" not in kp:
                         kp["Level_1b"] = []
                     kp["Level_1b"].append((cname, csv))
-        #self.update_annotations()
+        # self.update_annotations()

--- a/pcpfm/Experiment.py
+++ b/pcpfm/Experiment.py
@@ -1,11 +1,11 @@
-'''
-Experiment.py contains the pipeline's implementation of the Experiment object which in turn 
-inherits from the Experiment object in the metdatamodel. 
+"""
+Experiment.py contains the pipeline's implementation of the Experiment object which in turn
+inherits from the Experiment object in the metdatamodel.
 
 The Experiment is largely a computational aid and orchestrates an analysis. This includes
-keeping track of intermediate results and acquisitions. 
+keeping track of intermediate results and acquisitions.
 
-'''
+"""
 
 import os
 import random
@@ -15,13 +15,13 @@ import json
 import subprocess
 import multiprocessing as mp
 import pandas as pd
-import matplotlib.colors as mcolors
 import asari
 from metDataModel import core
 from .utils import recursive_encoder, file_operations, flatten_nested_dicts
 from . import Acquisition
 from . import EmpCpds
 from . import FeatureTable
+
 
 class Experiment(core.Experiment):
     """
@@ -30,7 +30,6 @@ class Experiment(core.Experiment):
     This super vague constructor was useful during testing, now
     will explicitly define all the fields.
     """
-
 
     # this needs to be removed but determines where intermediates are stored
     subdirectories = {
@@ -42,7 +41,7 @@ class Experiment(core.Experiment):
         "ms2_directory": "ms2_acquisitions/",
         "qaqc_figs": "QAQC_figs/",
         "asari_subdirectory": "asari/",
-        "output_subdirectory": "output/"
+        "output_subdirectory": "output/",
     }
 
     # need to minimize parameters
@@ -77,38 +76,38 @@ class Experiment(core.Experiment):
         asari_subdirectory=None,
         output_subdirectory=None,
         ordered_samples=None,
-        parent_study=None
+        parent_study=None,
     ):
-        super().__init__(id=experiment_name,
-                         parent_study= parent_study if parent_study else '',
-                         species=species if species else '',
-                         tissue=tissue if tissue else '',
-                         provenance=provenance if provenance else {
-                                'generated_time': '',
-                                'generated_by': '',
-                                'input_filename': '',
-                                'preprocess_software': '',
-                                'preprocess_parameters': {}
-                            },
-                         chromatography= {
-                                'type': '',
-                                'total_time': '',
-                                'method_file': '',
-                                'column_model': '',
-                                'column_length': ''
-                            },
-                         instrumentation= {
-                                'type': '',
-                                'spectrometer': '',
-                                'method_file': '',
-                                'ionization': ''
-                            },
-                         ObservationAnnotation= {
-                                'sample_list': [],
-                                'file_sample_mapper': {}
-                            },
-                        #ordered_samples = ordered_samples if ordered_samples else [x.acq_name for x in acquisitions] if acquisitions else []
-                         )
+        super().__init__(
+            id=experiment_name,
+            parent_study=parent_study if parent_study else "",
+            species=species if species else "",
+            tissue=tissue if tissue else "",
+            provenance=provenance
+            if provenance
+            else {
+                "generated_time": "",
+                "generated_by": "",
+                "input_filename": "",
+                "preprocess_software": "",
+                "preprocess_parameters": {},
+            },
+            chromatography={
+                "type": "",
+                "total_time": "",
+                "method_file": "",
+                "column_model": "",
+                "column_length": "",
+            },
+            instrumentation={
+                "type": "",
+                "spectrometer": "",
+                "method_file": "",
+                "ionization": "",
+            },
+            ObservationAnnotation={"sample_list": [], "file_sample_mapper": {}},
+            # ordered_samples = ordered_samples if ordered_samples else [x.acq_name for x in acquisitions] if acquisitions else []
+        )
 
         self.experiment_directory = os.path.abspath(experiment_directory)
         self.acquisitions = acquisitions if acquisitions else []
@@ -116,7 +115,9 @@ class Experiment(core.Experiment):
         self.feature_tables = feature_tables if feature_tables else {}
         self.empCpds = empCpds if empCpds else {}
         self.log_transformed_feature_tables = (
-            list(set(log_transformed_feature_tables)) if log_transformed_feature_tables else []
+            list(set(log_transformed_feature_tables))
+            if log_transformed_feature_tables
+            else []
         )
         self.cosmetics = cosmetics if cosmetics else {}
         self.used_cosmetics = used_cosmetics if used_cosmetics else {}
@@ -152,7 +153,7 @@ class Experiment(core.Experiment):
     @property
     def experiment_name(self):
         return self.id
-    
+
     @property
     def study(self):
         return self.parent_study
@@ -202,7 +203,7 @@ class Experiment(core.Experiment):
             ms2_directory=full_subdirs["ms2_directory"],
             qaqc_figs=full_subdirs["qaqc_figs"],
             asari_subdirectory=full_subdirs["asari_subdirectory"],
-            output_subdirectory=full_subdirs["output_subdirectory"]
+            output_subdirectory=full_subdirs["output_subdirectory"],
         )
 
     def save(self):
@@ -212,7 +213,9 @@ class Experiment(core.Experiment):
         """
         try:
             save_path = os.path.join(self.experiment_directory, "experiment.json.tmp")
-            with open(os.path.join(save_path), "w", encoding="utf-8") as save_filehandle:
+            with open(
+                os.path.join(save_path), "w", encoding="utf-8"
+            ) as save_filehandle:
                 self.command_history.append(str(time.time()) + ":" + ";".join(sys.argv))
                 json.dump(recursive_encoder(self.__dict__), save_filehandle, indent=4)
                 file_operations["move"](save_path, save_path.replace(".tmp", ""))
@@ -227,7 +230,7 @@ class Experiment(core.Experiment):
 
         Args:
             experiment_json_filepath (str): path to the JSON file
-        
+
         Returns:
             an experiment object
 
@@ -266,8 +269,8 @@ class Experiment(core.Experiment):
                 ms2_directory=decoded_JSON["ms2_directory"],
                 qaqc_figs=decoded_JSON["qaqc_figs"],
                 asari_subdirectory=decoded_JSON["asari_subdirectory"],
-                output_subdirectory=decoded_JSON['output_subdirectory'],
-                parent_study=decoded_JSON['parent_study']
+                output_subdirectory=decoded_JSON["output_subdirectory"],
+                parent_study=decoded_JSON["parent_study"],
             )
         for x in decoded_JSON["acquisitions"]:
             experiment.acquisitions.append(
@@ -396,7 +399,7 @@ class Experiment(core.Experiment):
 
     def create_sample_annotation_table(self):
         """
-        Create the sample annotation table which maps samples to their metadata. 
+        Create the sample annotation table which maps samples to their metadata.
 
         Returns:
             dataframe: the table as a dataframe
@@ -406,7 +409,7 @@ class Experiment(core.Experiment):
             flat_acq_dict = flatten_nested_dicts(acquisition.__dict__)
             to_delete = []
             for key in flat_acq_dict:
-                if key.startswith('_Acquisition__'):
+                if key.startswith("_Acquisition__"):
                     to_delete.append(key)
             for key_to_delete in to_delete:
                 del flat_acq_dict[key_to_delete]
@@ -415,15 +418,15 @@ class Experiment(core.Experiment):
 
     def add_acquisition(self, acquisition, mode="link"):
         """
-        This method adds an acquisition to the list of acquisitions in the experiment, ensures 
-        there are no duplicates and then links or copies the acquisition, currently only as a 
+        This method adds an acquisition to the list of acquisitions in the experiment, ensures
+        there are no duplicates and then links or copies the acquisition, currently only as a
         .raw file, to the experiment directory
 
         Args:
 
         acquisition (object): an Acquistiion object
         mode (str): how to move acquisitions into the experiment, default "link", can be "copy"
-        method_field (str): this is the field to check for the method name, used to shortcircuit 
+        method_field (str): this is the field to check for the method name, used to shortcircuit
             MS2 determination
         """
         if os.path.exists(acquisition.source_filepath):
@@ -439,10 +442,8 @@ class Experiment(core.Experiment):
                     )
                 acquisition.mzml_filepath = target_path
             elif acquisition.source_filepath.endswith(".raw"):
-                target_path = os.path.join(
-                    self.raw_subdirectory, source_basepath
-                )
-                acquisition.raw_filepath = target_path 
+                target_path = os.path.join(self.raw_subdirectory, source_basepath)
+                acquisition.raw_filepath = target_path
             if target_path is not None and not os.path.exists(target_path):
                 file_operations[mode](acquisition.source_filepath, target_path)
                 self.acquisitions.append(acquisition)
@@ -462,20 +463,22 @@ class Experiment(core.Experiment):
             self.species = set()
         elif self.species is not set():
             self.species = set(self.species)
-        self.species.add(acquisition.metadata_tags.get('species', 'Unknown'))
+        self.species.add(acquisition.metadata_tags.get("species", "Unknown"))
         self.species = list(self.species)
         if self.tissue is None:
             self.tissue = set()
         elif self.tissue is not set():
             self.tissue = set(self.tissue)
-        self.tissue.add(acquisition.metadata_tags.get('species', 'Unknown'))
+        self.tissue.add(acquisition.metadata_tags.get("species", "Unknown"))
         self.tissue = list(self.tissue)
 
-    def generate_output(self, empCpd_moniker, table_moniker, comprehensive_output=False):
+    def generate_output(
+        self, empCpd_moniker, table_moniker, comprehensive_output=False
+    ):
         """
-        This generates and stores the the feature table, sample annotation table, and the 
-        feature annotation table to the output directory. It also copies the JSON for the 
-        desried empcpd and experiment to the directory. 
+        This generates and stores the the feature table, sample annotation table, and the
+        feature annotation table to the output directory. It also copies the JSON for the
+        desried empcpd and experiment to the directory.
 
         Args:
             empCpd_moniker (str): moniker of empcpd to use
@@ -486,18 +489,31 @@ class Experiment(core.Experiment):
         feature_table = self.retrieve_feature_table(table_moniker, True)
         feature_table.feature_table.to_csv(feature_table_path, sep="\t", index=False)
 
-        sample_annotation_table_path = os.path.join(self.output_subdirectory, "sample_annot_table.tsv")
+        sample_annotation_table_path = os.path.join(
+            self.output_subdirectory, "sample_annot_table.tsv"
+        )
         sample_annotation_table = self.create_sample_annotation_table()
-        sample_annotation_table.to_csv(sample_annotation_table_path, sep="\t", index=False)
+        sample_annotation_table.to_csv(
+            sample_annotation_table_path, sep="\t", index=False
+        )
 
-        annotation_table_path = os.path.join(self.output_subdirectory, "annotation_table.tsv")
+        annotation_table_path = os.path.join(
+            self.output_subdirectory, "annotation_table.tsv"
+        )
         empCpds = self.retrieve_empCpds(empCpd_moniker, True)
         annotation_table = empCpds.create_annotation_table(comprehensive_output)
         annotation_table.to_csv(annotation_table_path, sep="\t", index=False)
 
-        file_operations["copy"](self.retrieve_empCpds(empCpd_moniker, False), self.output_subdirectory)
-        file_operations["copy"](self.retrieve_feature_table(table_moniker, False), self.output_subdirectory)
-        file_operations["copy"](os.path.join(self.experiment_directory, "experiment.json"), self.output_subdirectory)
+        file_operations["copy"](
+            self.retrieve_empCpds(empCpd_moniker, False), self.output_subdirectory
+        )
+        file_operations["copy"](
+            self.retrieve_feature_table(table_moniker, False), self.output_subdirectory
+        )
+        file_operations["copy"](
+            os.path.join(self.experiment_directory, "experiment.json"),
+            self.output_subdirectory,
+        )
 
     def convert_raw_to_mzML(self, conversion_command, num_cores=4):
         """
@@ -550,7 +566,7 @@ class Experiment(core.Experiment):
 
     def filter_samples(self, sample_filter, return_field=None):
         """
-        Find the set of acquisitions that pass the provided filter and return either the 
+        Find the set of acquisitions that pass the provided filter and return either the
         acquisition object or the specified field of each passing sample
 
         Args:
@@ -581,7 +597,7 @@ class Experiment(core.Experiment):
         name_field="File Name",
         path_field="Filepath",
         sample_skip_list_fp=None,
-        file_mode="link"
+        file_mode="link",
     ):
         """
         For a given sequence file, create the experiment object, and add all acquisitions
@@ -603,7 +619,7 @@ class Experiment(core.Experiment):
         sample_skip_list = set()
         if sample_skip_list_fp:
             if sample_skip_list_fp.endswith(".txt"):
-                with open(sample_skip_list_fp, encoding='utf-8') as skip_list_fh:
+                with open(sample_skip_list_fp, encoding="utf-8") as skip_list_fh:
                     sample_skip_list = {x.strip() for x in skip_list_fh.readlines()}
 
         if not os.path.exists(os.path.join(experiment_directory, "experiment.json")):
@@ -667,7 +683,7 @@ class Experiment(core.Experiment):
         Standalone drop-in replacement.
         Uses Paul Tol's "muted" palette for colors and a curated set for markers.
         No external helpers or globals.
-        
+
         Expects `self.acquisitions` to be iterable with `metadata_tags[field]`.
         Caches results in `self.cosmetics` / `self.used_cosmetics` like original.
         """
@@ -697,7 +713,10 @@ class Experiment(core.Experiment):
             self.used_cosmetics = {}
 
         # quick cache hit
-        if provided_cos_type in self.cosmetics and field in self.cosmetics[provided_cos_type]:
+        if (
+            provided_cos_type in self.cosmetics
+            and field in self.cosmetics[provided_cos_type]
+        ):
             return self.cosmetics[provided_cos_type][field]
 
         # choose pool
@@ -729,7 +748,7 @@ class Experiment(core.Experiment):
             times = (n // len(pool)) + 1
             available = available + (pool * times)
 
-        #random.shuffle(available)
+        # random.shuffle(available)
         mapping = {u: available[i] for i, u in enumerate(uniques)}
 
         # update caches
@@ -741,7 +760,6 @@ class Experiment(core.Experiment):
             self.save()
 
         return mapping
-
 
     def batches(self, batch_field):
         """
@@ -779,7 +797,10 @@ class Experiment(core.Experiment):
         force (bool): if true, rerun asari if previously ran
         """
 
-        if ( not ("full" in self.feature_tables and "preferred" in self.feature_tables) or force):
+        if (
+            not ("full" in self.feature_tables and "preferred" in self.feature_tables)
+            or force
+        ):
             mapping = {
                 "$IONIZATION_MODE": self.ionization_mode,
                 "$CONVERTED_SUBDIR": self.converted_subdirectory,
@@ -788,19 +809,27 @@ class Experiment(core.Experiment):
             # find existing asari runs
             existing_dirs = []
             for _dir, _, _ in os.walk(self.experiment_directory):
-                if "asari_project" in _dir and os.path.isdir(_dir) and 'export' not in _dir:
+                if (
+                    "asari_project" in _dir
+                    and os.path.isdir(_dir)
+                    and "export" not in _dir
+                ):
                     existing_dirs.append(_dir)
 
             job = asari_cmd if isinstance(asari_cmd, list) else asari_cmd.split(" ")
             job = [mapping.get(f, f) for f in asari_cmd]
             completed_process = subprocess.run(job, check=False)
-            
-            #exit()
+
+            # exit()
             # find new asari run
             sub_dir = None
             for _dir, _, _ in os.walk(self.experiment_directory):
                 if _dir not in existing_dirs:
-                    if "asari_project" in _dir and os.path.isdir(_dir) and 'export' not in _dir:
+                    if (
+                        "asari_project" in _dir
+                        and os.path.isdir(_dir)
+                        and "export" not in _dir
+                    ):
                         sub_dir = _dir
                         break
             self.asari_subdirectory = os.path.join(self.experiment_directory, sub_dir)

--- a/pcpfm/FeatureTable.py
+++ b/pcpfm/FeatureTable.py
@@ -1,8 +1,8 @@
-'''
-This module implements the FeatureTable object, which is mostly a 
-wrapper around a pandas dataframe. This also includes methods to 
-QAQC and batch correct the feature table. 
-'''
+"""
+This module implements the FeatureTable object, which is mostly a
+wrapper around a pandas dataframe. This also includes methods to
+QAQC and batch correct the feature table.
+"""
 
 import os
 import sys
@@ -20,6 +20,7 @@ from sklearn.decomposition import PCA
 from sklearn.manifold import TSNE
 from matplotlib.patches import Patch
 from . import utils
+
 
 class FeatureTable:
     """
@@ -68,7 +69,7 @@ class FeatureTable:
         self.feature_table = feature_table
         self.moniker = moniker
 
-        #self.clean_columns()
+        # self.clean_columns()
         self.__mz_trees = {}
         self.__rt_trees = {}
 
@@ -79,9 +80,17 @@ class FeatureTable:
             "pearson": partial(self.correlation_heatmap, correlation_type="pearson"),
             "kendall": partial(self.correlation_heatmap, correlation_type="kendall"),
             "spearman": partial(self.correlation_heatmap, correlation_type="spearman"),
-            "log_pearson": partial(self.correlation_heatmap, correlation_type="pearson", log_transform=True),
-            "log_kendall": partial(self.correlation_heatmap, correlation_type="kendall", log_transform=True),
-            "log_spearman": partial(self.correlation_heatmap, correlation_type="spearman", log_transform=True),
+            "log_pearson": partial(
+                self.correlation_heatmap, correlation_type="pearson", log_transform=True
+            ),
+            "log_kendall": partial(
+                self.correlation_heatmap, correlation_type="kendall", log_transform=True
+            ),
+            "log_spearman": partial(
+                self.correlation_heatmap,
+                correlation_type="spearman",
+                log_transform=True,
+            ),
             "missing_feature_percentiles": self.missing_feature_percentiles,
             "missing_feature_distribution": self.missing_feature_distribution,
             "missing_feature_z_scores": self.MissingFeatureZScores,
@@ -110,7 +119,7 @@ class FeatureTable:
         """
         if mz_tol not in self.__mz_trees:
             self.__mz_trees[mz_tol] = intervaltree.IntervalTree()
-            for f_id, mz in self.feature_table[['id_number', 'mz']].values.tolist():
+            for f_id, mz in self.feature_table[["id_number", "mz"]].values.tolist():
                 mz_err = abs(mz / 1e6 * mz_tol)
                 self.__mz_trees[mz_tol].addi(mz - mz_err, mz + mz_err, f_id)
         return self.__mz_trees[mz_tol]
@@ -128,8 +137,12 @@ class FeatureTable:
         """
         if rt_tol not in self.__rt_trees:
             self.__rt_trees[rt_tol] = intervaltree.IntervalTree()
-            for f_id, rtime in self.feature_table[['id_number', 'rtime']].values.tolist():
-                self.__rt_trees[rt_tol].addi(rtime - abs(rt_tol), rtime + abs(rt_tol), f_id)
+            for f_id, rtime in self.feature_table[
+                ["id_number", "rtime"]
+            ].values.tolist():
+                self.__rt_trees[rt_tol].addi(
+                    rtime - abs(rt_tol), rtime + abs(rt_tol), f_id
+                )
         return self.__rt_trees[rt_tol]
 
     @property
@@ -138,9 +151,9 @@ class FeatureTable:
 
         Return a list of the column names in the feature table that are sample names.
 
-        This is used when filtering the feature tables. When we search the experiment 
+        This is used when filtering the feature tables. When we search the experiment
         for a set of samples with a given filter, this returns samples in the experiment
-        that may not be in the feature table. We can use this list tofilter out the 
+        that may not be in the feature table. We can use this list tofilter out the
         samples in the experiment not in the feature table.
 
         Returns:
@@ -171,8 +184,8 @@ class FeatureTable:
         has been log transformed already
 
         Some operations log transform the feature table before analysis. Multiple log
-        transforms would yield unwanted results so if an operation is going to log 
-        transform a feature table, check this first to ensure that it is has not 
+        transforms would yield unwanted results so if an operation is going to log
+        transform a feature table, check this first to ensure that it is has not
         already been log transformed.
 
         Returns:
@@ -204,8 +217,8 @@ class FeatureTable:
     def load(moniker, experiment):
         """
         This method yields a FeatureTable object when given a feature table moniker.
-        FeatureTables are registered with the experiment object using a moniker, a 
-        string that points to the file path for that feature table. This method 
+        FeatureTables are registered with the experiment object using a moniker, a
+        string that points to the file path for that feature table. This method
         queries the experiment object, gets the feature table path, and creates
         the object.
 
@@ -220,8 +233,13 @@ class FeatureTable:
         df = pd.read_csv(experiment.feature_tables[moniker], sep="\t")
         mzml_to_name = {}
         for acquisition in experiment.acquisitions:
-            if os.path.basename(acquisition.mzml_filepath).rstrip('.mzML') in df.columns:
-                mzml_to_name[os.path.basename(acquisition.mzml_filepath).rstrip('.mzML')] = acquisition.name
+            if (
+                os.path.basename(acquisition.mzml_filepath).rstrip(".mzML")
+                in df.columns
+            ):
+                mzml_to_name[
+                    os.path.basename(acquisition.mzml_filepath).rstrip(".mzML")
+                ] = acquisition.name
         renamed = df.rename(columns=mzml_to_name)
         return FeatureTable(
             renamed,
@@ -233,7 +251,7 @@ class FeatureTable:
         """
         This replaces all NaN and 0 values in the feature table with the specified fill_value
 
-        This is used primarially before log transforming the feature table to remove values 
+        This is used primarially before log transforming the feature table to remove values
         that cannot be log transformed
 
         :param fill_value: the value to replace NaN and 0 with, defaults to 1
@@ -241,23 +259,25 @@ class FeatureTable:
         """
         self.feature_table.fillna(0)
         for column in self.sample_columns:
-            self.feature_table[column] = [max(x, fill_value) for x in self.feature_table[column]]
+            self.feature_table[column] = [
+                max(x, fill_value) for x in self.feature_table[column]
+            ]
 
     def save(self, new_moniker=None, drop_invariants=True):
         """
         Save the feature table as a pandas-created .tsv and register the new on-disk location
-        with the experiment object using the specified new_moniker or reuse the existing moniker. 
+        with the experiment object using the specified new_moniker or reuse the existing moniker.
         By default this drops features that have no variance in the feature table. This can occur
-        when a sample or samples are dropped and one or more features are zero or interpolated 
+        when a sample or samples are dropped and one or more features are zero or interpolated
         only in the remaining samples.
 
-        When an operation is performed that modifies a feature table, the resulting feature table 
-        can be saved to disk using this method. The moniker for the feature table can be reused or 
-        a new moniker provided. If a new moniker is provided it cannot be preferred or full since 
+        When an operation is performed that modifies a feature table, the resulting feature table
+        can be saved to disk using this method. The moniker for the feature table can be reused or
+        a new moniker provided. If a new moniker is provided it cannot be preferred or full since
         we do not want to overwrite the asari results.
 
-        Dropping invariants is recommended to reduce the size of the feature table and prevent 
-        uninformative features from reaching downstream steps. There is no good reason to turn 
+        Dropping invariants is recommended to reduce the size of the feature table and prevent
+        uninformative features from reaching downstream steps. There is no good reason to turn
         it off, but the option exists.
 
         :param new_moniker: a new moniker to register the saved table with the experiment object, defaults to None
@@ -287,14 +307,16 @@ class FeatureTable:
         self.experiment.feature_tables[new_moniker] = output_path
         self.experiment.save()
         if os.path.exists(self.experiment.qaqc_figs + "/" + new_moniker):
-            utils.file_operations["delete"](self.experiment.qaqc_figs + "/" + new_moniker)
+            utils.file_operations["delete"](
+                self.experiment.qaqc_figs + "/" + new_moniker
+            )
 
     def save_fig_path(self, name):
         """
         Given a desired name for a figure, this returns the path to which this figure should be
         saved.
 
-        This ensures that the resulting path for the figure is a reasonable path without special 
+        This ensures that the resulting path for the figure is a reasonable path without special
         figures and is saved to the appropriate location in the experiment directory.
 
         :param name: desired name for the figure
@@ -308,8 +330,14 @@ class FeatureTable:
         if not os.path.exists(fig_path):
             os.makedirs(fig_path)
 
-        name += json.dumps(self.figure_params['color_by']) + json.dumps(self.figure_params['marker_by']) + json.dumps(self.figure_params['text_by'])
-        name = "".join(c for c in name if c.isalpha() or c.isdigit() or c==' ' or c=='_').rstrip()
+        name += (
+            json.dumps(self.figure_params["color_by"])
+            + json.dumps(self.figure_params["marker_by"])
+            + json.dumps(self.figure_params["text_by"])
+        )
+        name = "".join(
+            c for c in name if c.isalpha() or c.isdigit() or c == " " or c == "_"
+        ).rstrip()
 
         return os.path.join(fig_path, "_" + name + ".png")
 
@@ -325,7 +353,7 @@ class FeatureTable:
         bins=100,
     ):
         """
-        A single method is used to generate the figures for the FeatureTable. This allows for 
+        A single method is used to generate the figures for the FeatureTable. This allows for
         consistent looking figures to be generated.
 
         The permitted types of figures are:
@@ -336,8 +364,8 @@ class FeatureTable:
         "heatmap" - make a heatmap
 
         This will be refactored in the future but this method is responsible for generating
-        all figures related to FeatureTables. The figure paramaters such as color, markers, 
-        etc are stored as a datamember in the FeatureTable object. 
+        all figures related to FeatureTables. The figure paramaters such as color, markers,
+        etc are stored as a datamember in the FeatureTable object.
 
         :param figure_type: which figure type to make
         :type figure_type: str
@@ -374,7 +402,9 @@ class FeatureTable:
                 plt.ylabel(y_label)
                 if skip_annot is False:
                     if markers and colors:
-                        for x, y, c, m in zip(xs, ys, list(colors[0]), list(markers[0])):
+                        for x, y, c, m in zip(
+                            xs, ys, list(colors[0]), list(markers[0])
+                        ):
                             plt.scatter(x, y, c=c, marker=m, s=10)
                     elif markers and not colors:
                         for x, y, m in zip(xs, ys, list(markers[0])):
@@ -417,9 +447,11 @@ class FeatureTable:
                     )
             elif figure_type == "heatmap":
                 if colors:
-                    sns.clustermap(data, col_colors=colors, yticklabels=y_label, cmap='coolwarm')
+                    sns.clustermap(
+                        data, col_colors=colors, yticklabels=y_label, cmap="coolwarm"
+                    )
                 else:
-                    sns.clustermap(data, yticklabels=y_label, cmap='coolwarm')
+                    sns.clustermap(data, yticklabels=y_label, cmap="coolwarm")
                 plt.suptitle(title)
                 if fig_params["color_legend"]:
                     plt.tight_layout(rect=[0, 0, 0.75, 1])
@@ -435,9 +467,9 @@ class FeatureTable:
                     )
             elif figure_type == "clustermap":
                 if colors:
-                    sns.clustermap(data, col_colors=colors, cmap='coolwarm')
+                    sns.clustermap(data, col_colors=colors, cmap="coolwarm")
                 else:
-                    sns.clustermap(data, cmap='coolwarm')
+                    sns.clustermap(data, cmap="coolwarm")
                 plt.xticks
                 plt.suptitle(title)
                 if fig_params["color_legend"]:
@@ -496,11 +528,11 @@ class FeatureTable:
         self, query_mz=None, query_rt=None, mz_tolerance=None, rt_tolerance=None
     ):
         """
-        Given a query_mz and query_rt with corresponding tolerances in ppm and absolute units 
+        Given a query_mz and query_rt with corresponding tolerances in ppm and absolute units
         respectively find all features by id_number that have a matching mz and rtime.
 
-        All search fields are optional but if none are provided then all the features will be 
-        considered matching. The mz tolerance should be in ppm while the rtime tolerance should 
+        All search fields are optional but if none are provided then all the features will be
+        considered matching. The mz tolerance should be in ppm while the rtime tolerance should
         be provided in rtime units.
 
         :param query_mz: the mz to search for, defaults to None
@@ -528,7 +560,7 @@ class FeatureTable:
     def intensity_distribution(self, skip_zero=True):
         """
         This method generates various summaries of the intensity distribution in the feature table
-        this includes TICs, LogTICs, median and mean intensity values including and excluding zeros 
+        this includes TICs, LogTICs, median and mean intensity values including and excluding zeros
         and including the values after log transforming the intensities.
 
         Args:
@@ -577,8 +609,8 @@ class FeatureTable:
     def properties_distribution(self):
         """
         This method generates figures for the distribution (a histogram) of every parameter in
-        the feature table that is not id_number, parent_masstrack_id or actual intensities in 
-        the samples. Useful for examining a feature table. 
+        the feature table that is not id_number, parent_masstrack_id or actual intensities in
+        the samples. Useful for examining a feature table.
 
         """
         for column in self.non_sample_columns:
@@ -613,8 +645,8 @@ class FeatureTable:
 
     def median_correlation_outlier_detection(self, correlation_type="pearson"):
         """
-        The median correlation of a sample against all other samples can be expressed as a z-score 
-        against the median of ALL correlations in the experiment. A high or low Z-score indicates 
+        The median correlation of a sample against all other samples can be expressed as a z-score
+        against the median of ALL correlations in the experiment. A high or low Z-score indicates
         that the sample was poorly correlated with other smaples in the experiment.
 
         Args:
@@ -624,7 +656,9 @@ class FeatureTable:
         Returns:
             dict: QAQC_result dict
         """
-        correlation_result = self.correlation_heatmap(correlation_type=correlation_type, full_results=True)
+        correlation_result = self.correlation_heatmap(
+            correlation_type=correlation_type, full_results=True
+        )
         all_correlations = []
         median_correlations = {}
         for sample_name_1, corr_dict in correlation_result["Result"].items():
@@ -735,13 +769,27 @@ class FeatureTable:
         result_values = {
             "sum_intensity": dict(zip(self.sample_columns, intensity_sums)),
             "mean_intensity": dict(zip(self.sample_columns, mean_feature_intensity)),
-            "median_intensity": dict(zip(self.sample_columns, median_feature_intensity)),
-            "missing_dropped_sum_intensity": dict(zip(self.sample_columns, intensity_sums)),
-            "missing_dropped_mean_intensity": dict(zip(self.sample_columns, filtered_mean_feature_intensity)),
-            "missing_dropped_median_intensity": dict(zip(self.sample_columns, filtered_median_feature_intensity)),
-            "log_missing_dropped_sum_intensity": dict(zip(self.sample_columns, log_filtered_intensity_sum)),
-            "log_missing_dropped_mean_intensity": dict(zip(self.sample_columns, log_filtered_mean_feature_intensity)),
-            "log_missing_dropped_median_intensity": dict(zip(self.sample_columns, log_filtered_median_feature_intensity)),
+            "median_intensity": dict(
+                zip(self.sample_columns, median_feature_intensity)
+            ),
+            "missing_dropped_sum_intensity": dict(
+                zip(self.sample_columns, intensity_sums)
+            ),
+            "missing_dropped_mean_intensity": dict(
+                zip(self.sample_columns, filtered_mean_feature_intensity)
+            ),
+            "missing_dropped_median_intensity": dict(
+                zip(self.sample_columns, filtered_median_feature_intensity)
+            ),
+            "log_missing_dropped_sum_intensity": dict(
+                zip(self.sample_columns, log_filtered_intensity_sum)
+            ),
+            "log_missing_dropped_mean_intensity": dict(
+                zip(self.sample_columns, log_filtered_mean_feature_intensity)
+            ),
+            "log_missing_dropped_median_intensity": dict(
+                zip(self.sample_columns, log_filtered_median_feature_intensity)
+            ),
             "log_tics": dict(zip(self.sample_columns, log_tics)),
             "tics": dict(zip(self.sample_columns, tics)),
         }
@@ -750,17 +798,19 @@ class FeatureTable:
             results.append({"Type": k, "Config": {}, "Result": v})
         return results
 
-    def correlation_heatmap(self, correlation_type, log_transform=False, full_results=False):
+    def correlation_heatmap(
+        self, correlation_type, log_transform=False, full_results=False
+    ):
         """correlation_heatmap
 
-        Using a specified correlation function generate a correlation heatmap for the feature 
+        Using a specified correlation function generate a correlation heatmap for the feature
         table. Optionally, log transform the feature table first.
 
         The permitted correlation types are:
 
         "pearson", "spearman" or "kendall"
 
-        Only pearson will log_transform the feature table if enabled since the non-parametric 
+        Only pearson will log_transform the feature table if enabled since the non-parametric
         correlations will not be affected by the log transform.
 
         :param figure_params: dictionary with the figure params
@@ -785,7 +835,7 @@ class FeatureTable:
                     corr_matrix[i][j] = corr_matrix[j][i]
                 else:
                     corr = corr_method(val_s1, working_table[s2])
-                    if hasattr(corr, 'statistic'):
+                    if hasattr(corr, "statistic"):
                         corr_matrix[i][j] = corr.statistic
                     else:
                         corr_matrix[i][j] = corr[0][1]
@@ -817,7 +867,7 @@ class FeatureTable:
             result = {
                 "Type": title,
                 "Config": {"Metric": correlation_type, "LogTransformed": log_transform},
-                "Result": {"CorrMatrix": corr_matrix, "Samples": self.sample_columns}
+                "Result": {"CorrMatrix": corr_matrix, "Samples": self.sample_columns},
             }
         return result
 
@@ -900,7 +950,7 @@ class FeatureTable:
                 },
             }
             return result
-        except:
+        except BaseException:
             if perplexity > 0:
                 perplexity -= 1
                 return self.tsne(perplexity)
@@ -908,12 +958,12 @@ class FeatureTable:
 
     def missing_feature_percentiles(self):
         """
-        Calculate the distribution of missing features with respect to percent of smaples with 
+        Calculate the distribution of missing features with respect to percent of smaples with
         feature
 
         Args:
             feature_vector_matrix (np.ndarray): the selected feature matrix
-            interactive_plot (bool, optional): if True, interactive plots are made. 
+            interactive_plot (bool, optional): if True, interactive plots are made.
                 Defaults to False.
 
         Returns:
@@ -953,15 +1003,15 @@ class FeatureTable:
 
     def missing_feature_distribution(self, intensity_cutoff=0):
         """
-        Count the number of missing features or featuers below the specified intensity cutoff per 
+        Count the number of missing features or featuers below the specified intensity cutoff per
         features
 
         Args:
             feature_vector_matrix (np.ndarray): the selected feature matrix
             acquisition_names (list[str]): list of acquisition names
-            intensity_cutoff (int, optional): values below this intesnity are considered missing. 
+            intensity_cutoff (int, optional): values below this intesnity are considered missing.
                 Defaults to 0.
-            interactive_plot (bool, optional): if True, interactive plots are made. 
+            interactive_plot (bool, optional): if True, interactive plots are made.
                 Defaults to False.
 
         Returns:
@@ -1002,9 +1052,9 @@ class FeatureTable:
         Args:
             feature_vector_matrix (np.ndarray): the selected feature matrix
             acquisition_names (list[str]): list of acquisition names
-            intensity_cutoff (int, optional): values with greater intensiy are considered. 
+            intensity_cutoff (int, optional): values with greater intensiy are considered.
                 Defaults to 0.
-            interactive_plot (bool, optional): if True, interactive plots are made. 
+            interactive_plot (bool, optional): if True, interactive plots are made.
                 Defaults to False.
 
         Returns:
@@ -1044,7 +1094,7 @@ class FeatureTable:
         Args:
             feature_vector_matrix (np.ndarray): the selected feature matrix
             acquisition_names (list[str]): list of acquisition names
-            intensity_cutoff (int, optional): values above this intensity are considered. 
+            intensity_cutoff (int, optional): values above this intensity are considered.
                 Defaults to 0.
             interactive_plot (bool, optional): if True, plots are interactive. Defaults to False.
 
@@ -1083,9 +1133,9 @@ class FeatureTable:
         Args:
             feature_vector_matrix (np.ndarray): the selected feature matrix
             acquisition_names (list[str]): list of acquisition names
-            intensity_cutoff (int, optional): values below this intensity are considered missing. 
+            intensity_cutoff (int, optional): values below this intensity are considered missing.
                 Defaults to 0.
-            interactive_plot (bool, optional): if True, interactive plots are made. 
+            interactive_plot (bool, optional): if True, interactive plots are made.
                 Defaults to False.
 
         Returns:
@@ -1096,8 +1146,12 @@ class FeatureTable:
         )
         # this relies upon the sorted order of the dictionary, may not be safe in all Python versions
         sample_names = [*missing_feature_counts_result["Result"].keys()]
-        missing_feature_counts = np.array([*missing_feature_counts_result["Result"].values()])
-        missing_feature_z_scores = (missing_feature_counts - np.mean(missing_feature_counts)) / np.std(missing_feature_counts)
+        missing_feature_counts = np.array(
+            [*missing_feature_counts_result["Result"].values()]
+        )
+        missing_feature_z_scores = (
+            missing_feature_counts - np.mean(missing_feature_counts)
+        ) / np.std(missing_feature_counts)
         self.gen_figure(
             "scatter",
             dict(enumerate(missing_feature_z_scores)),
@@ -1117,12 +1171,12 @@ class FeatureTable:
 
     def drop_invariants(self, zeros_only=False):
         """
-        This method drops features that have all zero intensity or the same intensity across all 
+        This method drops features that have all zero intensity or the same intensity across all
         samples.
 
-        This situation occurs as a result of filtering. For instance if a contaiminant is only 
+        This situation occurs as a result of filtering. For instance if a contaiminant is only
         seen in the blanks, when the blanks are dropped from the feature table, that feature is
-        still in the table but will be zero (or an interpolated value) for the remaning samples. 
+        still in the table but will be zero (or an interpolated value) for the remaning samples.
         These features have no information and can complicate downstream analysis.
 
         :param zeros_only: if true, only drop features that are all zero, defaults to False
@@ -1186,14 +1240,14 @@ class FeatureTable:
         print("Dropping:")
         for x in starting_columns:
             if x not in self.feature_table.columns:
-                print("\t", x)    
+                print("\t", x)
 
     def drop_samples_by_filter(self, sample_filter, drop_others=False):
         """
         Given a sample filter, a dictionary as described elsewhere, drop all other samples.
 
         Args:
-            sample_filter (dict): the dictionary specifying the filter 
+            sample_filter (dict): the dictionary specifying the filter
             drop_others (bool, optional): if true, reverse the logic of the drop. Defaults to False.
         """
         to_drop = [acq.name for acq in self.experiment.filter_samples(sample_filter)]
@@ -1209,7 +1263,7 @@ class FeatureTable:
     def drop_samples_by_field(self, value, field, drop_others=False):
         """
         For a given field and a value for that field drop all samples that match or all samples
-        that do not match. 
+        that do not match.
 
         Args:
             value (str): the value for the field to be dropped
@@ -1226,19 +1280,19 @@ class FeatureTable:
         field in the filter called "conditions" which can accept keys ">" and
         "<" that control the logic of the comparison. Currently only numerical
         metrics can be used for dropping. The "Action" field is also need and can
-        accept the values "Keep" and "Drop" which specify what should happen to 
-        the sample that matches the filter. 
+        accept the values "Keep" and "Drop" which specify what should happen to
+        the sample that matches the filter.
 
         The permitted qaqc results for this filter are described in self.qaqc_results_to_key
-        and if the metric has not been evaluated, it will be evaluated on demand 
-        in this method. 
+        and if the metric has not been evaluated, it will be evaluated on demand
+        in this method.
 
         #todo - params seems unnecessary here
 
         Args:
             qaqc_filter (dict): a dict detailing the qaqc filter
             drop_others (bool, optional): if true, reverse the logic of the drop. Defaults to False.
-            params (dict, optional): the params from main, needed for figure_params. 
+            params (dict, optional): the params from main, needed for figure_params.
                 Defaults to None.
         """
         to_drop = []
@@ -1262,10 +1316,14 @@ class FeatureTable:
                     for qaqc_result in result:
                         qcqa_results = self.experiment.qcqa_results[self.moniker]
                         qcqa_results[qaqc_result["Type"]] = qaqc_result
-                        self.experiment.qcqa_results[self.moniker][qaqc_result["Type"]] = qaqc_result
+                        self.experiment.qcqa_results[self.moniker][
+                            qaqc_result["Type"]
+                        ] = qaqc_result
                 else:
                     print("No method found for " + field)
-            qaqc_results_for_field = self.experiment.qcqa_results[self.moniker].get(field, None)
+            qaqc_results_for_field = self.experiment.qcqa_results[self.moniker].get(
+                field, None
+            )
             if qaqc_results_for_field:
                 for sample, value in qaqc_results_for_field["Result"].items():
                     if not min_value < float(value) < max_value:
@@ -1296,14 +1354,14 @@ class FeatureTable:
     ):
         """blank_mask
 
-        Given a feature table containing samples that we consider blanks, drop all features in 
-        non-blank samples that do not have an intensity blank_intensity_ratio times higher than 
+        Given a feature table containing samples that we consider blanks, drop all features in
+        non-blank samples that do not have an intensity blank_intensity_ratio times higher than
         the mean intensity in the blanks.
 
         The blank samples are specified by the comibnation of blank_type and type_field. Non-blank
         samples are specified by sample_type and type_field in a similar manner.
 
-        If there are batches in the experiment, blank masking is done per-batch. Then dropped if 
+        If there are batches in the experiment, blank masking is done per-batch. Then dropped if
         the ratio condition is not true in one sample (if logic_mode is "or") or in all samples if
         logic_mode is "and". The batches are specified given a field in the metadata via the by_batch field.
 
@@ -1333,8 +1391,12 @@ class FeatureTable:
         def __all_logical(row, columns):
             return np.all(row[columns] == True)
 
-        blanks = self.experiment.filter_samples({query_field: {"includes": [blank_value]}})
-        samples = self.experiment.filter_samples({query_field: {"includes": [sample_value]}})
+        blanks = self.experiment.filter_samples(
+            {query_field: {"includes": [blank_value]}}
+        )
+        samples = self.experiment.filter_samples(
+            {query_field: {"includes": [sample_value]}}
+        )
         blank_names = [x.name for x in blanks if x.name in self.sample_columns]
         sample_names = [x.name for x in samples if x.name in self.sample_columns]
 
@@ -1385,9 +1447,9 @@ class FeatureTable:
         self.feature_table.drop(columns="mask_feature", inplace=True)
 
     def impute_missing_features(self, ratio=0.5, by_batch=None, method="min"):
-        """impute_missing_features 
+        """impute_missing_features
 
-        Fill zero values with a small value to make downstream stats more robust. This value is 
+        Fill zero values with a small value to make downstream stats more robust. This value is
         a multiplier of the minimum value for that feature observed across all samples, excluding
         zeros.
 
@@ -1405,38 +1467,48 @@ class FeatureTable:
 
         if by_batch:
             for _, b_sample_names in self.experiment.batches(by_batch).values():
-                b_sample_names = list(set(b_sample_names).intersection(set(self.sample_columns)))
-                i_v = self.feature_table.apply(__calc_impute_value, axis=1, args=(b_sample_names,))
+                b_sample_names = list(
+                    set(b_sample_names).intersection(set(self.sample_columns))
+                )
+                i_v = self.feature_table.apply(
+                    __calc_impute_value, axis=1, args=(b_sample_names,)
+                )
                 self.feature_table["interp_value"] = i_v
                 for sample_name in b_sample_names:
-                    interp_values = self.feature_table[[sample_name, "interp_value"]].max(axis=1)
+                    interp_values = self.feature_table[
+                        [sample_name, "interp_value"]
+                    ].max(axis=1)
                     self.feature_table[sample_name] = interp_values
                 self.feature_table.drop(columns="interp_value", inplace=True)
         else:
-            i_v = self.feature_table.apply(__calc_impute_value, axis=1, args=(self.sample_columns,))
-            self.feature_table["interp_value"] =  i_v
+            i_v = self.feature_table.apply(
+                __calc_impute_value, axis=1, args=(self.sample_columns,)
+            )
+            self.feature_table["interp_value"] = i_v
             for sample_name in self.sample_columns:
-                interp_values = self.feature_table[[sample_name, "interp_value"]].max(axis=1)
+                interp_values = self.feature_table[[sample_name, "interp_value"]].max(
+                    axis=1
+                )
                 self.feature_table[sample_name] = interp_values
             self.feature_table.drop(columns="interp_value", inplace=True)
 
     def TIC_normalize(
         self, tic_normalization_percentile=0.90, by_batch=None, normalize_mode="median"
     ):
-        """TIC_normalize 
+        """TIC_normalize
 
-        This method will normalize the features of each acquisition based on the TICs of 
-        the samples. In this case, the TICs are calculated only using features that are 
-        present in TIC_normalization_percentile or greater percent of the samples. 
+        This method will normalize the features of each acquisition based on the TICs of
+        the samples. In this case, the TICs are calculated only using features that are
+        present in TIC_normalization_percentile or greater percent of the samples.
 
         Normalize mode determines how the normalization factor will be calculated, using
-        either the mean or the median. 
+        either the mean or the median.
 
-        If by_batch is given, the normalization is performed in batches first with the 
-        batches determined by the field specified by_batch. Then all batches are normalized 
-        to one another. 
+        If by_batch is given, the normalization is performed in batches first with the
+        batches determined by the field specified by_batch. Then all batches are normalized
+        to one another.
 
-        :param TIC_normalization_percentile: only features in more than this 
+        :param TIC_normalization_percentile: only features in more than this
         percent of samples are used for TIC calcualtion, defaults to 0.90
         :type TIC_normalization_percentile: float
         :param by_batch: the field on which to group samples into batches
@@ -1530,15 +1602,17 @@ class FeatureTable:
 
     def batch_correct(self, by_batch):
         """
-        This method batch corrects the feature intensities. The 
-        batches are determined dynamically using the by_batch field. 
+        This method batch corrects the feature intensities. The
+        batches are determined dynamically using the by_batch field.
 
         :param by_batch: the field on which to batch sampels
         :type by_batch: str
         """
         if len(self.experiment.batches(by_batch).keys()) > 1:
             batch_idx_map = {}
-            for batch_idx, (_, acquisition_list) in enumerate(self.experiment.batches(by_batch).items()):
+            for batch_idx, (_, acquisition_list) in enumerate(
+                self.experiment.batches(by_batch).items()
+            ):
                 for acquisition in acquisition_list:
                     batch_idx_map[acquisition] = batch_idx
             batches = [batch_idx_map[x] for x in self.sample_columns]
@@ -1558,24 +1632,26 @@ class FeatureTable:
         :type log_mode: str, optional
         """
         for sample_name in self.sample_columns:
-            self.feature_table[sample_name] = utils.log_modes[log_mode](self.feature_table[sample_name] + 1)
+            self.feature_table[sample_name] = utils.log_modes[log_mode](
+                self.feature_table[sample_name] + 1
+            )
 
     def drop_missing_features(
         self, by_batch=None, drop_percentile=0.8, logic_mode="or"
     ):
-        """drop_missing_features 
-        
+        """drop_missing_features
+
         This method will drop features that are uncommon in the feature table.
 
         Drop_percentile is the threshold for inclusion.
 
-        :param by_batch: if provided, perform the operation on each batch separately. with 
+        :param by_batch: if provided, perform the operation on each batch separately. with
         batches defined by this field., defaults to None
         :type by_batch: str, optional
         :param drop_percentile: features present in this percent or fewer of samples are dropped
         , defaults to 0.8
         :type drop_percentile: float, optional
-        :param logic_mode: if by batch, drop any feature that fails the threshold in 'any' batch 
+        :param logic_mode: if by batch, drop any feature that fails the threshold in 'any' batch
         or 'all' batches, defaults to "or"
         :type logic_mode: str, optional
         """
@@ -1619,12 +1695,12 @@ class FeatureTable:
 
     def __gen_color_cosmetic_map(self, colorby, seed=None):
         """
-        This method generates the cosmetic map for the fields in colorby. Essentially, 
+        This method generates the cosmetic map for the fields in colorby. Essentially,
         this is a mapping of values for the fiels in colorby to colors for plotting.
 
         Args:
             colorby (list): list of fields that need colors
-            seed (int, optional): if provided, this sets the seed for RNG purposes. Should allow reproducible maps. 
+            seed (int, optional): if provided, this sets the seed for RNG purposes. Should allow reproducible maps.
             Defaults to None.
 
         Returns:
@@ -1633,17 +1709,19 @@ class FeatureTable:
         color_cosmetic_map = {}
         for color in colorby:
             cosmetic_map = self.experiment.generate_cosmetic_map(color, "colors", seed)
-            color_cosmetic_map.update({("colors", k): v for k, v in cosmetic_map.items()})
+            color_cosmetic_map.update(
+                {("colors", k): v for k, v in cosmetic_map.items()}
+            )
         return color_cosmetic_map
 
     def __gen_marker_cosmetic_map(self, markerby, seed=None):
         """
-        This method generates the cosmetic map for the fields in markerby. Essentially, 
+        This method generates the cosmetic map for the fields in markerby. Essentially,
         this is a mapping of values for the fiels in markerby to markers for plotting.
 
         Args:
             colorby (list): list of fields that need markers
-            seed (int, optional): if provided, this sets the seed for RNG purposes. Should allow reproducible maps. 
+            seed (int, optional): if provided, this sets the seed for RNG purposes. Should allow reproducible maps.
             Defaults to None.
 
         Returns:
@@ -1651,8 +1729,12 @@ class FeatureTable:
         """
         marker_cosmetic_map = {}
         for marker in markerby:
-            cosmetic_map = self.experiment.generate_cosmetic_map(marker, "markers", seed)
-            marker_cosmetic_map.update({("markers", k): v for k, v in cosmetic_map.items()})
+            cosmetic_map = self.experiment.generate_cosmetic_map(
+                marker, "markers", seed
+            )
+            marker_cosmetic_map.update(
+                {("markers", k): v for k, v in cosmetic_map.items()}
+            )
         return marker_cosmetic_map
 
     def generate_cosmetic(self, colorby=None, markerby=None, textby=None, seed=None):
@@ -1660,7 +1742,7 @@ class FeatureTable:
 
         Plots need colors, markers, and text fields. The colors and markers need to defined
         on the fly since they may not be known a priori. This method generates this mapping
-        based on the fields in coloryb, markerby and textby. 
+        based on the fields in coloryb, markerby and textby.
 
         :param colorby: list of fields that need colors, defaults to None
         :type colorby: list, optional
@@ -1669,7 +1751,7 @@ class FeatureTable:
         :param textby: list of fields to be used for text, defaults to None.
         largely here for future expansion
         :type textby: list, optional
-        :param seed: if provided, this sets the seed for RNG purposes. Should allow reproducible maps. 
+        :param seed: if provided, this sets the seed for RNG purposes. Should allow reproducible maps.
             Defaults to None.
         :type seed: int, optional
         :return: map of field values to colors, markers and text
@@ -1681,14 +1763,14 @@ class FeatureTable:
         cosmetics = {
             "colors": [[] for _ in colorby],
             "markers": [[] for _ in markerby],
-            "texts": [[] for _ in textby]
+            "texts": [[] for _ in textby],
         }
-        legends = {
-            "colors": {},
-            "markers": {}
-        }
+        legends = {"colors": {}, "markers": {}}
         acq_name_map = {acq.name: acq for acq in self.experiment.acquisitions}
-        input_name_map = {os.path.basename(acq.input_file): acq for acq in self.experiment.acquisitions}
+        input_name_map = {
+            os.path.basename(acq.input_file): acq
+            for acq in self.experiment.acquisitions
+        }
         for sample_name in self.sample_columns:
             if sample_name in acq_name_map:
                 acquisition = acq_name_map[sample_name]
@@ -1696,32 +1778,36 @@ class FeatureTable:
                 acquisition = acq_name_map[sample_name + ".mzML"]
             elif sample_name in input_name_map:
                 acquisition = input_name_map[sample_name]
-                
-            
 
-            #acquisition = acq_name_map[sample_name.split("___")[-1]]
+            # acquisition = acq_name_map[sample_name.split("___")[-1]]
             for i, x in enumerate(colorby):
                 value_for_cosmetic = acquisition.metadata_tags[x]
-                cosmetic_for_value = combined_cosmetic_map[("colors", value_for_cosmetic)]
+                cosmetic_for_value = combined_cosmetic_map[
+                    ("colors", value_for_cosmetic)
+                ]
                 cosmetics["colors"][i].append(cosmetic_for_value)
                 legends["colors"][value_for_cosmetic] = cosmetic_for_value
             for i, x in enumerate(markerby):
                 value_for_cosmetic = acquisition.metadata_tags[x]
-                cosmetic_for_value = combined_cosmetic_map[("markers", value_for_cosmetic)]
+                cosmetic_for_value = combined_cosmetic_map[
+                    ("markers", value_for_cosmetic)
+                ]
                 cosmetics["markers"][i].append(cosmetic_for_value)
                 legends["markers"][value_for_cosmetic] = cosmetic_for_value
             for i, x in enumerate(textby):
                 cosmetics["texts"][i].append(acquisition.metadata_tags[x])
-        cos_colors, cos_markers, cos_texts = [cosmetics[x] for x in ["colors", "markers", "texts"]]
+        cos_colors, cos_markers, cos_texts = [
+            cosmetics[x] for x in ["colors", "markers", "texts"]
+        ]
         leg_colors, leg_markers = [legends[x] for x in ["colors", "markers"]]
         return cos_colors, cos_markers, cos_texts, leg_colors, leg_markers
 
     def generate_figure_params(self, params):
         """
-        This method generates the parameters used for plotting. 
+        This method generates the parameters used for plotting.
 
         Args:
-            params (dict): the params passed on the CLI. 
+            params (dict): the params passed on the CLI.
         """
         for x in ["color_by", "marker_by", "text_by"]:
             if x in params and isinstance(params[x], str):
@@ -1740,7 +1826,7 @@ class FeatureTable:
             "marker_legend": marker_legend,
             "color_by": params["color_by"],
             "marker_by": params["marker_by"],
-            "text_by": params["text_by"]
+            "text_by": params["text_by"],
         }
 
     def QAQC(self, params):
@@ -1761,7 +1847,7 @@ class FeatureTable:
             intensity_analysis (bool, optional): Defaults to False.
             feature_distribution (bool, optional): Defaults to False.
             feature_outlier_detection (bool, optional): Defaults to False.
-        
+
         Args:
             params (dict): the params from the main process.
 

--- a/pcpfm/MSnSpectrum.py
+++ b/pcpfm/MSnSpectrum.py
@@ -1,5 +1,5 @@
 """
-MS2Spectrum contains the constructors for MS2 spectra. These are used for L1a and L2 annotations. 
+MS2Spectrum contains the constructors for MS2 spectra. These are used for L1a and L2 annotations.
 
 The actual MS2 comparisons are performed by matchms in the EmpCpds object.
 
@@ -10,10 +10,12 @@ from matchms.Spectrum import Spectrum
 import numpy as np
 from metDataModel import core
 
+
 class MS2Spectrum(core.Spectrum):
     """
     This represents an MS2 spectrum
     """
+
     def __init__(
         self,
         spec_id,
@@ -27,7 +29,7 @@ class MS2Spectrum(core.Spectrum):
         collision_energy=None,
         compound_name=None,
         annotations=None,
-        identifiers=None
+        identifiers=None,
     ):
         """_summary_
 
@@ -46,7 +48,9 @@ class MS2Spectrum(core.Spectrum):
         """
         super().__init__(spec_id)
         source = os.path.basename(source) if source != "" else os.path.basename(source)
-        self.precursor_ion_id = (str(precursor_mz) + "_" + str(precursor_rt) + "_" + os.path.basename(source))
+        self.precursor_ion_id = (
+            str(precursor_mz) + "_" + str(precursor_rt) + "_" + os.path.basename(source)
+        )
         self.spec_id = spec_id
         self.rtime = precursor_rt
         self.retention_time = precursor_rt
@@ -66,7 +70,6 @@ class MS2Spectrum(core.Spectrum):
             self.list_mz = []
             self.list_intensity = []
 
-
         self.annotations = [] if annotations is None else annotations
         self.compound_name = compound_name
         self.source = source
@@ -75,7 +78,7 @@ class MS2Spectrum(core.Spectrum):
     @property
     def prec_mz(self):
         """
-        Simply a shortcut for accessing the precursor_ion_mz field. This is used because the 
+        Simply a shortcut for accessing the precursor_ion_mz field. This is used because the
         precursor_ion_mz is long and can yield lines that are too long for pylint.
 
         Returns:
@@ -119,7 +122,7 @@ class MS2Spectrum(core.Spectrum):
         Args:
             other_MS2 (object): the other MS2 spectrum, typically from a database
             score (float): the score from the similarity comparison
-            matched_peaks (int): number of peaks 
+            matched_peaks (int): number of peaks
             annotation_level (str, optional): a string designating the annotation level. Defaults to "Unspecified".
         """
         self.annotations.append(
@@ -129,12 +132,12 @@ class MS2Spectrum(core.Spectrum):
                 "db_precursor_mz": other_ms2.precursor_ion_mz,
                 "db_precursor_rt": other_ms2.rtime,
                 "reference_id": other_ms2.compound_name,
-                #"list_mz": [x[0] for x in other_ms2.matchms_spectrum.peaks],
-                #"list_intensity": [x[1] for x in other_ms2.matchms_spectrum.peaks],
+                # "list_mz": [x[0] for x in other_ms2.matchms_spectrum.peaks],
+                # "list_intensity": [x[1] for x in other_ms2.matchms_spectrum.peaks],
                 "primary_db": other_ms2.source,
                 "source": self.source,
                 "annotation_level": annotation_level,
-                "identifiers": other_ms2.identifiers
+                "identifiers": other_ms2.identifiers,
             }
         )
 

--- a/pcpfm/Report.py
+++ b/pcpfm/Report.py
@@ -1,5 +1,5 @@
 """
-This module implements the report object which is a wrapper around an fpdf object. 
+This module implements the report object which is a wrapper around an fpdf object.
 
 The reports are meant to be a high-level overview of an experiment, the feature tables,
 empcpds, etc and summarize some of the qaqc results.
@@ -15,12 +15,13 @@ from pip._vendor import pkg_resources
 from fpdf import FPDF
 import matplotlib.pyplot as plt
 from . import FeatureTable
-from . import utils
+
 
 class ReportPDF(FPDF):
     """
     Wrapper around FPDF with consistent header and footer.
     """
+
     def __init__(self, header_text):
         self.header_text = header_text
         super().__init__()
@@ -28,37 +29,43 @@ class ReportPDF(FPDF):
     def header(self):
         print(self.page_no())
         if self.page_no() > 1:
-            self.set_font('Arial', 'B', 15)
-            #self.cell(0, 10, self.header_text, ln=True, align='C')
+            self.set_font("Arial", "B", 15)
+            # self.cell(0, 10, self.header_text, ln=True, align='C')
             self.ln(5)
 
     def footer(self):
         self.set_y(-15)
-        self.set_font('Arial', 'I', 8)
+        self.set_font("Arial", "I", 8)
         if self.page_no() > 1:
-            self.cell(0, 10, f'Page {self.page_no() - 1} - {self.header_text}', 0, 0, 'C')
+            self.cell(
+                0, 10, f"Page {self.page_no() - 1} - {self.header_text}", 0, 0, "C"
+            )
 
-class Report():
+
+class Report:
     """
-    The report object allows the creation of a pdf report. The reports 
-    are defined using templates. 
+    The report object allows the creation of a pdf report. The reports
+    are defined using templates.
 
-    A template is a JSON-formatted list of dictionaries. Each dictionary 
+    A template is a JSON-formatted list of dictionaries. Each dictionary
     corresponds one-to-one with a method of this object. Which method
     the dictionary is intended to call is defined by the dictionary's
-    "section" field. The section field value should be the name of a 
-    method for this object. 
+    "section" field. The section field value should be the name of a
+    method for this object.
     """
+
     def __init__(self, experiment, parameters) -> None:
         self.experiment = experiment
         self.parameters = parameters
 
-        self.default_font = ['Arial', '', 12]
-        report_title = 'PCPFM Report - ' + self.experiment.experiment_directory.split("/")[-1]
+        self.default_font = ["Arial", "", 12]
+        report_title = (
+            "PCPFM Report - " + self.experiment.experiment_directory.split("/")[-1]
+        )
         self.report = ReportPDF(report_title)
-        #self.report.add_page()
+        # self.report.add_page()
         self.report.set_font(*self.default_font)
-        self.max_width = round(self.report.line_width * 900,0)
+        self.max_width = round(self.report.line_width * 900, 0)
         self.style = self.__preprocess_style(self.parameters["report_config"])
         self.__create_report()
 
@@ -69,15 +76,15 @@ class Report():
         """
         self.report.add_page()
         self.__section_head("Table of Contents")
-        
+
         page_num = 2  # cover = 1, TOC = 2
         toc_lines = []
         for section in self.__preprocess_style(self.parameters["report_config"]):
             name = section["section"]
             if name in {"cover_page", "table_of_contents", "save"}:
                 continue
-            if section['section'] == 'figure':
-                label = section['name']
+            if section["section"] == "figure":
+                label = section["name"]
             else:
                 label = name.replace("_", " ").title()
             if "table" in section and section["table"] != "*":
@@ -90,21 +97,23 @@ class Report():
         for label, page in toc_lines:
             label_str = f"{label}"
             label_width = self.report.get_string_width(label_str)
-            dots = "." * int((180 - label_width - 10) / self.report.get_string_width("."))
+            dots = "." * int(
+                (180 - label_width - 10) / self.report.get_string_width(".")
+            )
             self.report.cell(0, 10, f"{label_str} {dots} {page}", ln=True)
 
     def __section_table(self, rows, col_widths=None, header=True, font_size=12):
         """
         Draws a well-aligned table in the PDF.
-        
+
         Args:
             rows (list of lists): Each sublist is a row of strings/numbers.
             col_widths (list of floats): Optional fixed column widths in mm.
             header (bool): Whether the first row is a header.
             font_size (int): Font size for table content.
         """
-        self.report.set_font(self.default_font[0], 'B' if header else '', font_size)
-        
+        self.report.set_font(self.default_font[0], "B" if header else "", font_size)
+
         # Auto-compute column widths if not provided
         if not col_widths:
             max_cols = max(len(r) for r in rows)
@@ -113,18 +122,18 @@ class Report():
 
         for i, row in enumerate(rows):
             if i == 1 and header:
-                self.report.set_font(self.default_font[0], '', font_size)
+                self.report.set_font(self.default_font[0], "", font_size)
             for j, cell in enumerate(row):
                 self.report.cell(col_widths[j], 10, str(cell), border=1)
             self.report.ln()
 
     def __preprocess_style(self, style):
         """
-        This function takes the provided style and checks that it has 
-        the required save section and that the defined sections are 
+        This function takes the provided style and checks that it has
+        the required save section and that the defined sections are
         valid. Invalid sections are removed here. Furthermore, fields
-        such as "texts" that can occur at the same level as "sections" 
-        are then inserted into the approprate location. 
+        such as "texts" that can occur at the same level as "sections"
+        are then inserted into the approprate location.
 
         :param style: the JSON configuration of the report
 
@@ -134,16 +143,23 @@ class Report():
             for top_level_field in style.keys():
                 if top_level_field in section:
                     if section[top_level_field] in style[top_level_field]:
-                        section[top_level_field] = style[top_level_field][section[top_level_field]]
+                        section[top_level_field] = style[top_level_field][
+                            section[top_level_field]
+                        ]
         valid_sections = []
         for section in style["sections"]:
             try:
                 getattr(self, section["section"])
                 valid_sections.append(section)
             except AttributeError:
-                print(section["section"] + "is not a valid section!\nValid sections include: ")
+                print(
+                    section["section"]
+                    + "is not a valid section!\nValid sections include: "
+                )
                 for method in dir(Report):
-                    if not method.startswith("__") and not method.startswith("_Report__"):
+                    if not method.startswith("__") and not method.startswith(
+                        "_Report__"
+                    ):
                         print("\t", method)
         section_names = [x["section"] for x in valid_sections]
         if "save" not in section_names:
@@ -206,13 +222,12 @@ class Report():
 
         self.experiment.save()
 
-
     def __reset_font(self):
         """
-        This method resets the font of the report to the default. This 
-        is needed because the report's font is set at a report-wide 
+        This method resets the font of the report to the default. This
+        is needed because the report's font is set at a report-wide
         level and must be changed each time a different font, size, or
-        typesetting is required. 
+        typesetting is required.
         """
         self.report.set_font(*self.default_font)
 
@@ -220,21 +235,21 @@ class Report():
         """
         This writes the header for a section. This uses a larger font
         and sets it to be in bold.
-        
+
         :param title: the title of the section
         """
         self.report.cell(80)
-        self.report.set_font(self.default_font[0], 'B', self.default_font[2])
-        self.report.cell(30, 10, title, 0, 0, 'C')
+        self.report.set_font(self.default_font[0], "B", self.default_font[2])
+        self.report.cell(30, 10, title, 0, 0, "C")
         self.__reset_font()
         self.report.ln(5)
 
     def __section_line(self, content, options=None):
         """
-        This writes a line in a section. Optionally, the font can be 
-        made bold by passing 'B' in options. 
+        This writes a line in a section. Optionally, the font can be
+        made bold by passing 'B' in options.
 
-        TODO: all of these functions for writing lines can be 
+        TODO: all of these functions for writing lines can be
         unified with a single command that takes multiple params
 
         :param content: what to write in the line
@@ -243,7 +258,7 @@ class Report():
         """
         options = set(options) if options is not None else set()
         if "bold" in options:
-            self.report.set_font(self.default_font[0], 'B', self.default_font[2])
+            self.report.set_font(self.default_font[0], "B", self.default_font[2])
             self.report.cell(30, 10, content, 0, 0, "B")
             self.__reset_font()
         else:
@@ -253,19 +268,19 @@ class Report():
     def __section_text(self, text, options=None):
         """
         This writes a block of text in a section, one line at a time
-        using the __section_line function. This also handles chopping 
-        up a line into pieces that can fit on the page (i.e., word 
+        using the __section_line function. This also handles chopping
+        up a line into pieces that can fit on the page (i.e., word
         wrapping)
 
-        TODO: all of these functions for writing lines can be 
+        TODO: all of these functions for writing lines can be
         unified with a single command that takes multiple params
 
         :param text: what to write in the line
         :param options: an iterable with text options valid options
             include: 'B' for bold.
         """
-        text = ' '.join(text.split(None))
-        text = ' '.join(text.split("\n"))
+        text = " ".join(text.split(None))
+        text = " ".join(text.split("\n"))
         i = 0
         for line in textwrap.wrap(text, width=95):
             self.__section_line(line, options=options)
@@ -274,8 +289,8 @@ class Report():
 
     def TICs(self, section_desc):
         """
-        This generates, if not pre-existing, and includes the TIC of 
-        each acquisition in the experiment to the report. 
+        This generates, if not pre-existing, and includes the TIC of
+        each acquisition in the experiment to the report.
 
         Requires: None
         """
@@ -283,7 +298,7 @@ class Report():
             try:
                 tic_path = acquisition.TIC()
                 self.report.image(tic_path, w=self.max_width)
-            except:
+            except BaseException:
                 print(section_desc)
 
     def study_summary(self, section_desc):
@@ -295,26 +310,28 @@ class Report():
         """
         self.report.add_page()
         self.__section_head("Experiment Overview")
-        
+
         exp = self.experiment
 
         total_samples = len(exp.acquisitions)
-        
+
         type_counts = {}
         for acq in exp.acquisitions:
             stype = getattr(acq, "sample_type", "Unknown")
             if stype == "Unknown":
                 stype = "Study Sample"
             type_counts[stype] = type_counts.get(stype, 0) + 1
-        type_summary = ", ".join([f"{count} {stype}" for stype, count in type_counts.items()])
+        type_summary = ", ".join(
+            [f"{count} {stype}" for stype, count in type_counts.items()]
+        )
 
-        #num_metadata_tags = len(getattr(exp.metadata, "columns", {}))
+        # num_metadata_tags = len(getattr(exp.metadata, "columns", {}))
         num_feature_tables = len(exp.feature_tables)
 
         summary_text = (
             f"A total of {total_samples} samples were analyzed.\n"
             f"Samples by type: {type_summary}.\n"
-            #f"{num_metadata_tags} metadata tags were provided.\n"
+            # f"{num_metadata_tags} metadata tags were provided.\n"
             f"The experiment has {num_feature_tables} feature tables: ."
         )
 
@@ -326,10 +343,19 @@ class Report():
         """
         self.report.add_page()
         self.__section_head("Annotation Summary")
-        if 'text' in section_desc:
-            self.__section_text(section_desc['text'])
+        if "text" in section_desc:
+            self.__section_text(section_desc["text"])
 
-        rows = [["Name", "#EmpCpds", "#L4 Annotated", "#L2 Annotated", "#L1b Annotated", "#L1a Annotated"]]
+        rows = [
+            [
+                "Name",
+                "#EmpCpds",
+                "#L4 Annotated",
+                "#L2 Annotated",
+                "#L1b Annotated",
+                "#L1a Annotated",
+            ]
+        ]
 
         for empcpd_moniker in self.experiment.empCpds.keys():
             try:
@@ -339,25 +365,28 @@ class Report():
                 for kp in empcpds.dict_empcpds.values():
                     num_l1b += int(bool(kp.get("Level_1b", [])))
                     num_l4 += int(bool(kp.get("Level_4")))
-                    annotations = [annotation["annotation_level"]
-                                for spectrum in kp.get("MS2_Spectra", [])
-                                for annotation in spectrum.get("annotations", [])]
+                    annotations = [
+                        annotation["annotation_level"]
+                        for spectrum in kp.get("MS2_Spectra", [])
+                        for annotation in spectrum.get("annotations", [])
+                    ]
                     num_l2 += int("Level_2" in annotations)
                     num_l1a += int("Level_1a" in annotations)
 
-                rows.append([
-                    empcpd_moniker,
-                    len(empcpds.dict_empcpds),
-                    num_l4,
-                    num_l2,
-                    num_l1b,
-                    num_l1a
-                ])
-            except:
+                rows.append(
+                    [
+                        empcpd_moniker,
+                        len(empcpds.dict_empcpds),
+                        num_l4,
+                        num_l2,
+                        num_l1b,
+                        num_l1a,
+                    ]
+                )
+            except BaseException:
                 pass
 
         self.__section_table(rows)
-
 
     def summary(self, section_desc):
         self.report.add_page()
@@ -365,27 +394,28 @@ class Report():
         subsections = [
             ("sample_desc_txt", "Sample Description"),
             ("experiment_goal_txt", "Goal"),
-            ("assay_summary", "Assay Summary"), 
+            ("assay_summary", "Assay Summary"),
             ("analysis_summary", "Analysis Summary"),
-            ("results_summary", "Results Summary")
+            ("results_summary", "Results Summary"),
         ]
-        for (key, title) in subsections:
+        for key, title in subsections:
             self.__section_line(f"{title}")
             self.report.ln(5)
-            self.__section_text(section_desc.get(key, ''))
-
+            self.__section_text(section_desc.get(key, ""))
 
     def table_summary(self, section_desc):
         """
-        This summarizes the feature tables in the experiment. 
+        This summarizes the feature tables in the experiment.
 
         Requires: None
         """
         self.report.add_page()
         self.__section_head("Feature Table Summary")
-        if 'text' in section_desc:
-            self.__section_text(section_desc['text'])
-        tables = [x for x in self.experiment.feature_tables.keys() if "__internal" not in x]
+        if "text" in section_desc:
+            self.__section_text(section_desc["text"])
+        tables = [
+            x for x in self.experiment.feature_tables.keys() if "__internal" not in x
+        ]
         rows = [["Table Name", "Num Samples", "Num Features"]]
         for table in tables:
             ft = self.experiment.retrieve_feature_table(table, True)
@@ -398,17 +428,17 @@ class Report():
         """
         self.report.add_page()
         self.__section_head("empCpd Table Summary")
-        if 'text' in section_desc:
-            self.__section_text(section_desc['text'])
+        if "text" in section_desc:
+            self.__section_text(section_desc["text"])
 
         rows = [["EmpCpd Name", "Num Khipus", "Num Features"]]
         for empcpd in self.experiment.empCpds.keys():
             try:
                 obj = self.experiment.retrieve_empCpds(empcpd, True)
                 rows.append([empcpd, obj.num_khipus, obj.num_features])
-            except:
+            except BaseException:
                 pass
-        
+
         self.__section_table(rows)
 
     def command_history(self, section_desc):
@@ -421,10 +451,18 @@ class Report():
         rows = [["Timestamp", "Command"]]
         for entry in self.experiment.command_history:
             ts, cmd = entry.split(":", 1)
-            timestamp = datetime.datetime.fromtimestamp(float(ts)).strftime("%Y-%m-%d %H:%M:%S")
+            timestamp = datetime.datetime.fromtimestamp(float(ts)).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
             rows.append([timestamp, cmd])
 
-        self.__section_table(rows, col_widths=[50, self.report.w - self.report.l_margin - self.report.r_margin - 50])
+        self.__section_table(
+            rows,
+            col_widths=[
+                50,
+                self.report.w - self.report.l_margin - self.report.r_margin - 50,
+            ],
+        )
 
     def cover_page(self, section_desc):
         """
@@ -438,46 +476,56 @@ class Report():
             - logo_path (str): Path to a logo image
         """
         self.report.add_page()
-        self.report.set_font('Arial', 'B', 24)
+        self.report.set_font("Arial", "B", 24)
         self.report.ln(100)
         if "title" in section_desc:
-            self.report.cell(0, 40, section_desc["title"], ln=True, align='C')
+            self.report.cell(0, 40, section_desc["title"], ln=True, align="C")
         if "subtitle" in section_desc:
-            self.report.set_font('Arial', '', 16)
-            self.report.cell(0, 10, section_desc["subtitle"], ln=True, align='C')
+            self.report.set_font("Arial", "", 16)
+            self.report.cell(0, 10, section_desc["subtitle"], ln=True, align="C")
         if "author" in section_desc:
             self.report.ln(10)
-            self.report.set_font('Arial', '', 12)
-            self.report.cell(0, 10, "Prepared by: " + section_desc["author"], ln=True, align='C')
-        date_str = section_desc.get("date", datetime.datetime.today().strftime('%B %d, %Y    %H:%M:%S'))
+            self.report.set_font("Arial", "", 12)
+            self.report.cell(
+                0, 10, "Prepared by: " + section_desc["author"], ln=True, align="C"
+            )
+        date_str = section_desc.get(
+            "date", datetime.datetime.today().strftime("%B %d, %Y    %H:%M:%S")
+        )
         self.report.ln(5)
-        self.report.cell(0, 10, "Date: " + date_str, ln=True, align='C')
+        self.report.cell(0, 10, "Date: " + date_str, ln=True, align="C")
         if "logo_path" in section_desc and os.path.exists(section_desc["logo_path"]):
             self.report.image(section_desc["logo_path"], x=80, w=50)
 
     def version_summary(self, section_desc):
         """
-        This summarizes each command that has been executed in the 
-        analysis. 
+        This summarizes each command that has been executed in the
+        analysis.
 
         Requires: None
         """
         self.report.add_page()
         self.__section_head("Software Metadata Summary")
         self.report.ln(5)
-        __PCPFM_version = pkg_resources.get_distribution('pcpfm').version
+        __PCPFM_version = pkg_resources.get_distribution("pcpfm").version
 
-        __version_text = f'PCPFM version {__PCPFM_version} was used for data processing\n'
-        __version_text += 'The following software libraries were employed for the analysis: '
+        __version_text = (
+            f"PCPFM version {__PCPFM_version} was used for data processing\n"
+        )
+        __version_text += (
+            "The following software libraries were employed for the analysis: "
+        )
 
         submodules = []
-        for req in pkg_resources.working_set.by_key['pcpfm'].requires():
-            submodules.append(f'{req.name}v.{pkg_resources.get_distribution(req.name).version}')
+        for req in pkg_resources.working_set.by_key["pcpfm"].requires():
+            submodules.append(
+                f"{req.name}v.{pkg_resources.get_distribution(req.name).version}"
+            )
         __version_text += " ,".join(submodules)
         self.__section_text(__version_text)
         self.report.ln(5)
 
-        __machine_description = f'Report generated and analysis performed using a '
+        __machine_description = "Report generated and analysis performed using a "
         __machine_description += f"{platform.machine()} system running {platform.system()} as the operating system."
         __uname_string = ",".join(platform.uname())
         __machine_description += f"Python Version was {platform.python_revision()} and system uname was {__uname_string}"
@@ -506,7 +554,9 @@ class Report():
                 command_order.append(command)
                 time_required.append(time_sums)
         total_time = current_time - start_time
-        self.__section_text("Total time for analysis: " + str(total_time / 60) + " minutes")
+        self.__section_text(
+            "Total time for analysis: " + str(total_time / 60) + " minutes"
+        )
         plt.bar(command_order, time_required)
         plt.title("Time Required per Command")
         name = "/tmp/" + str(uuid.uuid4) + ".png"
@@ -520,9 +570,9 @@ class Report():
         Requires: None
         """
         pass
-        #timestamp_string = 'Report generated on ' + str(datetime.datetime.now())
-        #self.__section_head("Timestamp")
-        #self.__section_line(timestamp_string)
+        # timestamp_string = 'Report generated on ' + str(datetime.datetime.now())
+        # self.__section_head("Timestamp")
+        # self.__section_line(timestamp_string)
 
     def save(self, section_desc):
         """
@@ -538,61 +588,85 @@ class Report():
         self.report.output(report_path)
 
     def figure_live(self, section_desc):
-        feature_table = self.experiment.retrieve_feature_table(section_desc["table"], True)
+        feature_table = self.experiment.retrieve_feature_table(
+            section_desc["table"], True
+        )
         params_for_figure = dict(self.parameters)
-        params_for_figure['all'] = False
-        params_for_figure['save_plots'] = True
+        params_for_figure["all"] = False
+        params_for_figure["save_plots"] = True
         feature_table.generate_figure_params(params_for_figure)
         figure_path = feature_table.save_fig_path(section_desc["name"])
         if section_desc["name"] in feature_table.qaqc_result_to_key:
-                    params_for_figure[feature_table.qaqc_result_to_key[section_desc["name"]]] = True
-                    feature_table.QAQC(params_for_figure)
-
+            params_for_figure[
+                feature_table.qaqc_result_to_key[section_desc["name"]]
+            ] = True
+            feature_table.QAQC(params_for_figure)
 
     def figure(self, section_desc):
         """
-        This inserts a figure into the report. Since all figures are 
-        currently QAQC figures from feature tables, this method 
-        requires specifying a table name and a qaqc result to 
-        visualize. 
+        This inserts a figure into the report. Since all figures are
+        currently QAQC figures from feature tables, this method
+        requires specifying a table name and a qaqc result to
+        visualize.
 
         Requires: "table" - the moniker for the table
                   "name" - name for the qaqc result to add figure of
 
-        The valid fields of name are populated at runtime for this 
-        method and will be displayed if an incorrect name field is 
+        The valid fields of name are populated at runtime for this
+        method and will be displayed if an incorrect name field is
         provided.
 
         """
-        feature_table = self.experiment.retrieve_feature_table(section_desc["table"], True)
+        feature_table = self.experiment.retrieve_feature_table(
+            section_desc["table"], True
+        )
         params_for_figure = dict(self.parameters)
-        params_for_figure['all'] = False
-        params_for_figure['save_plots'] = True
+        params_for_figure["all"] = False
+        params_for_figure["save_plots"] = True
         feature_table.generate_figure_params(params_for_figure)
         figure_path = feature_table.save_fig_path(section_desc["name"])
         try:
             if os.path.exists(figure_path):
                 self.report.add_page()
-                self.__section_line("Table: " + section_desc["table"] + "  " + "Figure: " + section_desc["name"])
+                self.__section_line(
+                    "Table: "
+                    + section_desc["table"]
+                    + "  "
+                    + "Figure: "
+                    + section_desc["name"]
+                )
                 self.report.ln(10)
-                self.report.image(figure_path, w=self.max_width-10)
+                self.report.image(figure_path, w=self.max_width - 10)
             else:
-                feature_table = self.experiment.retrieve_feature_table(section_desc["table"], True)
+                feature_table = self.experiment.retrieve_feature_table(
+                    section_desc["table"], True
+                )
                 params_for_figure = dict(self.parameters)
-                params_for_figure['all'] = False
-                params_for_figure['save_plots'] = True
+                params_for_figure["all"] = False
+                params_for_figure["save_plots"] = True
                 if section_desc["name"] in feature_table.qaqc_result_to_key:
-                    params_for_figure[feature_table.qaqc_result_to_key[section_desc["name"]]] = True
+                    params_for_figure[
+                        feature_table.qaqc_result_to_key[section_desc["name"]]
+                    ] = True
                     feature_table.QAQC(params_for_figure)
                     self.report.add_page()
-                    self.__section_line("Table: " + section_desc["table"] + "  " + "Figure: " + section_desc["name"])
+                    self.__section_line(
+                        "Table: "
+                        + section_desc["table"]
+                        + "  "
+                        + "Figure: "
+                        + section_desc["name"]
+                    )
                     self.report.ln(10)
                     self.report.image(figure_path, w=self.max_width)
             if "text" in section_desc and section_desc["text"]:
                 self.__section_text(section_desc["text"])
-        except:
+        except BaseException:
             pass
+
 
 # this updates the docstring for report
 qaqc_names = list(FeatureTable.FeatureTable.qaqc_result_to_key.keys())
-getattr(Report, "figure").__doc__ += "\nValid name values are: \n\t" + "\n\t".join(qaqc_names)
+getattr(Report, "figure").__doc__ += "\nValid name values are: \n\t" + "\n\t".join(
+    qaqc_names
+)

--- a/pcpfm/Report2.py
+++ b/pcpfm/Report2.py
@@ -4,6 +4,7 @@ from typing import Callable, Dict, List, Optional, Tuple, Any
 from fpdf import FPDF
 import matplotlib.pyplot as plt
 
+
 # ---------- Theme ----------
 @dataclass(frozen=True)
 class ReportTheme:
@@ -20,10 +21,9 @@ class ReportTheme:
 
 # ---------- Experiment Mixins --------- #
 
+
 def retrieve_figure(experiment, feature_table):
-    params = experiment.parameters 
-
-
+    params = experiment.parameters
 
 
 # ---------- PDF Wrapper ----------
@@ -34,15 +34,15 @@ class ReportPDF(FPDF):
         super().__init__()
 
     def header(self):
-        self.set_font(self.theme.font_family, 'B', 15)
+        self.set_font(self.theme.font_family, "B", 15)
         self.cell(80)
-        self.cell(30, 10, self.header_text, 0, 0, 'C')
+        self.cell(30, 10, self.header_text, 0, 0, "C")
         self.ln(10)
 
     def footer(self):
         self.set_y(-15)
-        self.set_font(self.theme.font_family, 'I', 8)
-        self.cell(0, 10, f'Page {self.page_no()}', 0, 0, 'C')
+        self.set_font(self.theme.font_family, "I", 8)
+        self.cell(0, 10, f"Page {self.page_no()}", 0, 0, "C")
 
 
 # ---------- Figure Handling ----------
@@ -51,7 +51,7 @@ class FigureRenderer:
         self.dpi = dpi
 
     def __call__(self, fig, path: str):
-        fig.savefig(path, dpi=self.dpi, bbox_inches='tight')
+        fig.savefig(path, dpi=self.dpi, bbox_inches="tight")
         plt.close(fig)
 
 
@@ -62,15 +62,15 @@ class SectionDispatcher:
         self.theme = theme
         self.renderer = FigureRenderer(theme.dpi)
         self.dispatch: Dict[str, Callable[[Dict[str, Any]], None]] = {
-            'text': self._text,
-            'figure': self._figure,
-            'toc': self._toc,
-            'cover': self._cover,
+            "text": self._text,
+            "figure": self._figure,
+            "toc": self._toc,
+            "cover": self._cover,
         }
         self._toc_positions: List[Tuple[str, int]] = []
 
     def run(self, section: Dict[str, Any]):
-        kind = section.get('section')
+        kind = section.get("section")
         fn = self.dispatch.get(kind)
         if fn:
             fn(section)
@@ -78,49 +78,49 @@ class SectionDispatcher:
     # --- handlers ---
     def _text(self, sec: Dict[str, Any]):
         self.pdf.set_font(*self.theme.font_tuple)
-        title = sec.get('title')
+        title = sec.get("title")
         if title:
             self._section_title(title)
-        txt = sec.get('text', '')
+        txt = sec.get("text", "")
         self.pdf.multi_cell(0, 8, txt)
 
     def _figure(self, sec: Dict[str, Any]):
-        fig = sec.get('figure')
-        save_path = sec.get('save_path')
-        caption = sec.get('caption', '')
+        fig = sec.get("figure")
+        save_path = sec.get("save_path")
+        caption = sec.get("caption", "")
         if fig and save_path:
             self.renderer(fig, save_path)
             self.pdf.image(save_path, w=180)
             if caption:
                 self.pdf.ln(2)
-                self.pdf.set_font(self.theme.font_family, 'I', 9)
+                self.pdf.set_font(self.theme.font_family, "I", 9)
                 self.pdf.multi_cell(0, 5, caption)
 
     def _toc(self, _: Dict[str, Any]):
         # Insert TOC at end: capture current page, then render
         cur_y = self.pdf.get_y()
         self.pdf.add_page()
-        self.pdf.set_font(self.theme.font_family, 'B', 16)
-        self.pdf.cell(0, 10, 'Table of Contents', ln=1)
-        self.pdf.set_font(self.theme.font_family, '', 12)
+        self.pdf.set_font(self.theme.font_family, "B", 16)
+        self.pdf.cell(0, 10, "Table of Contents", ln=1)
+        self.pdf.set_font(self.theme.font_family, "", 12)
         for title, page in self._toc_positions:
-            self.pdf.cell(0, 8, f'{title} ....... {page}', ln=1)
+            self.pdf.cell(0, 8, f"{title} ....... {page}", ln=1)
         self.pdf.set_y(cur_y)
 
     def _cover(self, sec: Dict[str, Any]):
         self.pdf.add_page()
-        self.pdf.set_font(self.theme.font_family, 'B', 28)
+        self.pdf.set_font(self.theme.font_family, "B", 28)
         self.pdf.ln(60)
-        title = sec.get('title', 'Report')
-        self.pdf.cell(0, 20, title, 0, 1, 'C')
-        subtitle = sec.get('subtitle', '')
+        title = sec.get("title", "Report")
+        self.pdf.cell(0, 20, title, 0, 1, "C")
+        subtitle = sec.get("subtitle", "")
         if subtitle:
-            self.pdf.set_font(self.theme.font_family, '', 16)
-            self.pdf.cell(0, 10, subtitle, 0, 1, 'C')
+            self.pdf.set_font(self.theme.font_family, "", 16)
+            self.pdf.cell(0, 10, subtitle, 0, 1, "C")
 
     # --- helpers ---
     def _section_title(self, title: str):
-        self.pdf.set_font(self.theme.font_family, 'B', 14)
+        self.pdf.set_font(self.theme.font_family, "B", 14)
         self._toc_positions.append((title, self.pdf.page_no()))
         self.pdf.ln(6)
         self.pdf.cell(0, 10, title, ln=1)
@@ -130,48 +130,61 @@ class SectionDispatcher:
 # ---------- Style Validation ----------
 class ReportStyle:
     def __init__(self, cfg: Dict[str, Any]):
-        raw = cfg.get('sections', [])
-        self.sections: List[Dict[str, Any]] = [s for s in raw if isinstance(s, dict) and 'section' in s]
+        raw = cfg.get("sections", [])
+        self.sections: List[Dict[str, Any]] = [
+            s for s in raw if isinstance(s, dict) and "section" in s
+        ]
 
 
 # ---------- Main Report ----------
 class Report:
-    def __init__(self, experiment, parameters: Dict[str, Any], output_path: Optional[str] = None, theme: Optional[ReportTheme] = None):
+    def __init__(
+        self,
+        experiment,
+        parameters: Dict[str, Any],
+        output_path: Optional[str] = None,
+        theme: Optional[ReportTheme] = None,
+    ):
         self.experiment = experiment
         self.parameters = parameters
         self.theme = theme or ReportTheme()
 
         header = f"PCPFM Report - {os.path.basename(experiment.experiment_directory)}"
-        header = ''
+        header = ""
         self.pdf = ReportPDF(header, self.theme)
-        #self.pdf.add_page()
+        # self.pdf.add_page()
         self.pdf.set_font(*self.theme.font_tuple)
 
-        style = ReportStyle(parameters['report_config'])
+        style = ReportStyle(parameters["report_config"])
         dispatcher = SectionDispatcher(self.pdf, self.theme)
 
         for sec in style.sections:
             dispatcher.run(sec)
 
-        self.output_path = output_path or os.path.join(self.experiment.experiment_directory, 'report.pdf')
+        self.output_path = output_path or os.path.join(
+            self.experiment.experiment_directory, "report.pdf"
+        )
         self.pdf.output(self.output_path)
 
 
 # ---------- Example ----------
-if __name__ == '__main__':
-    import json
+if __name__ == "__main__":
     import datetime
     from pcpfm.Experiment import Experiment
 
-    exp = Experiment('P_HILICneg', '/Users/mitchjo/07202025_GPR32/Analysis/pcpfm/P_HILICneg')
+    exp = Experiment(
+        "P_HILICneg", "/Users/mitchjo/07202025_GPR32/Analysis/pcpfm/P_HILICneg"
+    )
     params = {
-            "report_config": {
-                "sections":
-                    [
-                        {'section': 'cover', 'subtitle': datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")},
-                        {'section': 'figure', 'table': 'full', 'name': 'pca', 'text': 'PCA'},
-                        {'section': 'toc'}
-                    ]
-                }
-            }
+        "report_config": {
+            "sections": [
+                {
+                    "section": "cover",
+                    "subtitle": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                },
+                {"section": "figure", "table": "full", "name": "pca", "text": "PCA"},
+                {"section": "toc"},
+            ]
+        }
+    }
     Report(exp, params, output_path="./testing.pdf")

--- a/pcpfm/__init__.py
+++ b/pcpfm/__init__.py
@@ -1,10 +1,10 @@
 __version__ = "1.1.5"
 
-from . import main
-from . import Acquisition
-from . import EmpCpds
-from . import Experiment
-from . import FeatureTable
-from . import MSnSpectrum
-from . import Report
-from . import utils
+from . import main as main
+from . import Acquisition as Acquisition
+from . import EmpCpds as EmpCpds
+from . import Experiment as Experiment
+from . import FeatureTable as FeatureTable
+from . import MSnSpectrum as MSnSpectrum
+from . import Report as Report
+from . import utils as utils

--- a/pcpfm/__main__.py
+++ b/pcpfm/__main__.py
@@ -1,4 +1,4 @@
 from pcpfm.main import main
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/pcpfm/default_parameters.py
+++ b/pcpfm/default_parameters.py
@@ -7,7 +7,7 @@ This needs to be cleaned up.
 import os
 
 PARAMETERS = {
-    #"preprocessing_config": "preprocessing_examples/defaultpreprocessing.json",
+    # "preprocessing_config": "preprocessing_examples/defaultpreprocessing.json",
     "annot_mz_tolerance": 5,
     "annot_rt_tolerance": 30,
     "khipu_mz_tolerance": 5,
@@ -27,27 +27,29 @@ PARAMETERS = {
     "report_config": "default_configs/default_report.json",
     "moniker": "default",
     "multicores": 4,
-    "conversion_command": ['$(which mono)', 
-                           '$BUILTIN_CONVERTER', 
-                           '-f=2', 
-                           '-i', 
-                           '$RAW_PATH', 
-                           '-b',
-                           '$OUT_PATH', 
-                           ' >/dev/null'],
-    "asari_command": [
-        '/Users/mitchjo/Library/Python/3.11/bin/asari',
-        'process',
-        '-m',
-        '$IONIZATION_MODE', 
-        '-i',
-        '$CONVERTED_SUBDIR',
-        '-o',
-        '$ASARI_SUBDIR',
-        '--anno',
-        'False'
+    "conversion_command": [
+        "$(which mono)",
+        "$BUILTIN_CONVERTER",
+        "-f=2",
+        "-i",
+        "$RAW_PATH",
+        "-b",
+        "$OUT_PATH",
+        " >/dev/null",
     ],
-    "filter": '',
+    "asari_command": [
+        "/Users/mitchjo/Library/Python/3.11/bin/asari",
+        "process",
+        "-m",
+        "$IONIZATION_MODE",
+        "-i",
+        "$CONVERTED_SUBDIR",
+        "-o",
+        "$ASARI_SUBDIR",
+        "--anno",
+        "False",
+    ],
+    "filter": "",
     "save_plots": True,
     "interactive_plots": False,
     "color_by": [],
@@ -71,7 +73,7 @@ PARAMETERS = {
     "query_field": "Sample Type",
     "blank_intensity_ratio": 3,
     "by_batch": None,
-    "batch_blanking_logic": 'or',
+    "batch_blanking_logic": "or",
     "drop_name": None,
     "drop_field": None,
     "drop_others": None,
@@ -81,11 +83,14 @@ PARAMETERS = {
     "TIC_normalization_percentile": 0.90,
     "normalize_value": "median",
     "feature_retention_percentile": 0.50,
-    "feature_drop_logic": 'or',
+    "feature_drop_logic": "or",
     "interpolation_ratio": 0.5,
     "interpolate_method": "min",
     "log_transform_mode": "log2",
-    "targets": ["annotation_sources/hmdb_metabolites.json", "annotation_sources/LMSD.json"],
+    "targets": [
+        "annotation_sources/hmdb_metabolites.json",
+        "annotation_sources/LMSD.json",
+    ],
     "search_isotopologues": False,
     "MS1_annotation_name": "MS1_annotations",
     "MS2_annotation_name": "MS2_annotations",
@@ -106,21 +111,22 @@ PARAMETERS = {
     "scan_experiment": True,
     "force": False,
     "file_mode": "link",
-    "comprehensive_output": False
+    "comprehensive_output": False,
 }
 
 this_abs_dir = os.path.abspath(os.path.dirname(__file__))
 
 new_target_files = []
-for v in PARAMETERS['targets']:
+for v in PARAMETERS["targets"]:
     new_target_files.append(os.path.join(this_abs_dir, v))
-PARAMETERS['targets'] = new_target_files
+PARAMETERS["targets"] = new_target_files
 
-if PARAMETERS["conversion_command"][1] == '$BUILTIN_CONVERTER':
-    path = this_abs_dir + '/ThermoRawFileParser.exe'
+if PARAMETERS["conversion_command"][1] == "$BUILTIN_CONVERTER":
+    path = this_abs_dir + "/ThermoRawFileParser.exe"
     PARAMETERS["conversion_command"][1] = path
 
 for k, v in PARAMETERS.items():
-    if isinstance(v, str) and (v.endswith(".json") or v.endswith(".msp") or v.endswith('.txt')):
+    if isinstance(v, str) and (
+        v.endswith(".json") or v.endswith(".msp") or v.endswith(".txt")
+    ):
         PARAMETERS[k] = os.path.join(this_abs_dir, v)
-        

--- a/pcpfm/main.py
+++ b/pcpfm/main.py
@@ -1,8 +1,8 @@
 """
-This is the main module in the pcpfm. All functions that are intended to be called by 
+This is the main module in the pcpfm. All functions that are intended to be called by
 an end user are located here, although API access to the underlying modules is possible.
 
-Each function in the Main object maps to a single command on the command line. 
+Each function in the Main object maps to a single command on the command line.
 """
 
 import os
@@ -14,25 +14,27 @@ import zipfile
 import gdown
 import requests
 import tarfile
-import shutil 
 
 from . import Experiment
 from . import EmpCpds
 from . import default_parameters
 from . import Report
 
-def download_from_cloud_storage(src, dst, extract_dir=None, delete_after_extract=True, use_gdown=False):
+
+def download_from_cloud_storage(
+    src, dst, extract_dir=None, delete_after_extract=True, use_gdown=False
+):
     """
     Downloads a file from either Google Drive or a direct URL, extracts it, and optionally deletes the archive.
 
     Parameters:
     - src (str): URL or path to the source file in the cloud.
     - dst (str): Local path where the file should be downloaded.
-    - extract_dir (str): Directory where the contents should be extracted. 
+    - extract_dir (str): Directory where the contents should be extracted.
                         Defaults to the same directory as dst.
-    - delete_after_extract (bool): Whether to delete the archive file after extraction. 
+    - delete_after_extract (bool): Whether to delete the archive file after extraction.
                                 Defaults to True.
-    - use_gdown (bool): If True, use gdown to download from Google Drive; 
+    - use_gdown (bool): If True, use gdown to download from Google Drive;
                         otherwise, download from a direct URL.
     """
     # Download the file
@@ -40,24 +42,24 @@ def download_from_cloud_storage(src, dst, extract_dir=None, delete_after_extract
         gdown.download(src, output=dst, quiet=False)
     else:
         response = requests.get(src, stream=True)
-        with open(dst, 'wb') as file:
+        with open(dst, "wb") as file:
             for chunk in response.iter_content(chunk_size=8192):
                 file.write(chunk)
-    
+
     # Determine the extraction directory
     if extract_dir is None:
         extract_dir = os.path.dirname(dst)
 
     # Extract the file based on its extension
     __EXTRACTED = False
-    if dst.endswith('.zip'):
-        with zipfile.ZipFile(dst, 'r') as zip_ref:
+    if dst.endswith(".zip"):
+        with zipfile.ZipFile(dst, "r") as zip_ref:
             zip_ref.extractall(extract_dir)
             __EXTRACTED = True
             print(f"{dst} downloaded and extracted")
-    elif dst.endswith(('.tar.gz', '.tgz', '.tar')):
-        with tarfile.open(dst, 'r:*') as tar_ref:
-            tar_ref.extractall(extract_dir, filter='data')
+    elif dst.endswith((".tar.gz", ".tgz", ".tar")):
+        with tarfile.open(dst, "r:*") as tar_ref:
+            tar_ref.extractall(extract_dir, filter="data")
             __EXTRACTED = True
             print(f"{dst} downloaded and extracted")
     else:
@@ -67,148 +69,158 @@ def download_from_cloud_storage(src, dst, extract_dir=None, delete_after_extract
     if delete_after_extract and __EXTRACTED:
         os.remove(dst)
 
-class Main():
+
+class Main:
     """
-    This is simply a wrapper around all the CLI functions. By putting them in 
+    This is simply a wrapper around all the CLI functions. By putting them in
     this object, we can do clever things with getattr()
     """
 
     @staticmethod
     def process_params():
         """
-        This process parses the command line arguments and returns the 
-        parameters in a dictionary. Default parameters are specified in 
+        This process parses the command line arguments and returns the
+        parameters in a dictionary. Default parameters are specified in
         the example_parameters.py file and some are read dynamically from
-        .json files as specified in that file. Note that any parameters 
+        .json files as specified in that file. Note that any parameters
         given as .json files will be assumed to be a file path to a json
-        file and read as such. This allows complex datastructures to be 
-        specified for some parameters. 
+        file and read as such. This allows complex datastructures to be
+        specified for some parameters.
 
         :return: parameters dictionary
         """
-        all_subcommands = "\n".join([m for m in dir(Main) if not m.startswith('__')])
-        with open(os.path.join(os.path.dirname(__file__), '__init__.py'), encoding='utf-8') as f:
+        all_subcommands = "\n".join([m for m in dir(Main) if not m.startswith("__")])
+        with open(
+            os.path.join(os.path.dirname(__file__), "__init__.py"), encoding="utf-8"
+        ) as f:
             for x in f.readlines():
-                if '__version__' in x:
+                if "__version__" in x:
                     version = "v" + x.split("=")[-1].strip()[1:-1]
         params = default_parameters.PARAMETERS
-        parser = argparse.ArgumentParser(description='pcpfm, LC-MS end-to-end processing', prog='pcpfm')
-        parser.add_argument('--version', action='version', version="pcpfm " + version)
-        parser.add_argument('subcommand', metavar='subcommand', 
-                            help='one of the subcommands: ' + all_subcommands)
-        parser.add_argument('-p', '--parameters')
-        parser.add_argument('-m', '--mode', default=None)
-        parser.add_argument('--ppm', default=5, type=int)
-        parser.add_argument('-s', '--sequence')
-        parser.add_argument('-c', '--cores', type=int)
-        parser.add_argument('-MS2_dir')
-        parser.add_argument('-f', '--filter')
-        parser.add_argument('-j', '--project')
-        parser.add_argument('-o', '--output')
-        parser.add_argument('-i', '--input')
-        parser.add_argument('--name_field', default='File Name')
-        parser.add_argument('--path_field', default='Filepath')
-        parser.add_argument('--asari_command')
-        parser.add_argument('-tm', '--table_moniker')
-        parser.add_argument('-em', '--empCpd_moniker')
-        parser.add_argument('-nm', '--new_moniker')
-        parser.add_argument('-cb', '--color_by', default=[])
-        parser.add_argument('-bb', '--by_batch')
-        parser.add_argument('-mb', '--marker_by', default=[])
-        parser.add_argument('-tb', '--text_by', default=[])
-        parser.add_argument('--all')
-        parser.add_argument('--pca')
-        parser.add_argument('--tsne')
-        parser.add_argument('--spearman'),
-        parser.add_argument('--kendall'),
-        parser.add_argument('--missing_feature_distribution')
-        parser.add_argument('--missing_feature_percentiles')
-        parser.add_argument('--median_correlation_outlier_detection')
-        parser.add_argument('--missing_feature_outlier_detection')
-        parser.add_argument('--intensity_analysis')
-        parser.add_argument('--feature_distribution')
-        parser.add_argument('--feature_outlier_detection')
-        parser.add_argument('--interactive_plots', default=False)
-        parser.add_argument('--save_plots', default=False)
-        parser.add_argument('--khipu_isotopes')
-        parser.add_argument('--khipu_charges')
-        parser.add_argument('--khipu_extended_adducts')
-        parser.add_argument('--khipu_adducts_pos')
-        parser.add_argument('--khipu_adducts_neg')
-        parser.add_argument('--khipu_rt_tolerance')
-        parser.add_argument('--blank_value')
-        parser.add_argument('--sample_value')
-        parser.add_argument('--query_field')
-        parser.add_argument('--blank_intensity_ratio')
-        parser.add_argument('--drop_name')
-        parser.add_argument('--drop_field')
-        parser.add_argument('--drop_value')
-        parser.add_argument('--drop_others')
-        parser.add_argument('--qaqc_filter')
-        parser.add_argument('--conversion_command')
-        parser.add_argument('--preprocessing_config')
-        parser.add_argument('--new_csv_path')
-        parser.add_argument('--TIC_normalization_percentile')
-        parser.add_argument('--normalize_value')
-        parser.add_argument('--feature_retention_percentile')
-        parser.add_argument('--interpolation_ratio')
-        parser.add_argument('--ms2_dir')
-        parser.add_argument('--report_config')
-        parser.add_argument('--sample_for_ratio')
-        parser.add_argument('--deriv_formula')
-        parser.add_argument('--msp_files')
-        parser.add_argument('--skip_list')
-        parser.add_argument('--add_singletons')
-        parser.add_argument('--extra_asari', default=None)
-        parser.add_argument('--targets')
-        parser.add_argument('--annot_rt_tolerance')
-        parser.add_argument('--annot_mz_tolerance')
-        parser.add_argument('--accept_licenses')
-        parser.add_argument('--scan_experiment', default=False)
-        parser.add_argument('--force', default=False)
-        parser.add_argument('--file_mode', default="link")
-        parser.add_argument('--comprehensive_output', default=False)
-        parser.add_argument('--msp_files_gc')
-        parser.add_argument('--retention_index_standards')
-        parser.add_argument('--auto_drop')
+        parser = argparse.ArgumentParser(
+            description="pcpfm, LC-MS end-to-end processing", prog="pcpfm"
+        )
+        parser.add_argument("--version", action="version", version="pcpfm " + version)
+        parser.add_argument(
+            "subcommand",
+            metavar="subcommand",
+            help="one of the subcommands: " + all_subcommands,
+        )
+        parser.add_argument("-p", "--parameters")
+        parser.add_argument("-m", "--mode", default=None)
+        parser.add_argument("--ppm", default=5, type=int)
+        parser.add_argument("-s", "--sequence")
+        parser.add_argument("-c", "--cores", type=int)
+        parser.add_argument("-MS2_dir")
+        parser.add_argument("-f", "--filter")
+        parser.add_argument("-j", "--project")
+        parser.add_argument("-o", "--output")
+        parser.add_argument("-i", "--input")
+        parser.add_argument("--name_field", default="File Name")
+        parser.add_argument("--path_field", default="Filepath")
+        parser.add_argument("--asari_command")
+        parser.add_argument("-tm", "--table_moniker")
+        parser.add_argument("-em", "--empCpd_moniker")
+        parser.add_argument("-nm", "--new_moniker")
+        parser.add_argument("-cb", "--color_by", default=[])
+        parser.add_argument("-bb", "--by_batch")
+        parser.add_argument("-mb", "--marker_by", default=[])
+        parser.add_argument("-tb", "--text_by", default=[])
+        parser.add_argument("--all")
+        parser.add_argument("--pca")
+        parser.add_argument("--tsne")
+        (parser.add_argument("--spearman"),)
+        (parser.add_argument("--kendall"),)
+        parser.add_argument("--missing_feature_distribution")
+        parser.add_argument("--missing_feature_percentiles")
+        parser.add_argument("--median_correlation_outlier_detection")
+        parser.add_argument("--missing_feature_outlier_detection")
+        parser.add_argument("--intensity_analysis")
+        parser.add_argument("--feature_distribution")
+        parser.add_argument("--feature_outlier_detection")
+        parser.add_argument("--interactive_plots", default=False)
+        parser.add_argument("--save_plots", default=False)
+        parser.add_argument("--khipu_isotopes")
+        parser.add_argument("--khipu_charges")
+        parser.add_argument("--khipu_extended_adducts")
+        parser.add_argument("--khipu_adducts_pos")
+        parser.add_argument("--khipu_adducts_neg")
+        parser.add_argument("--khipu_rt_tolerance")
+        parser.add_argument("--blank_value")
+        parser.add_argument("--sample_value")
+        parser.add_argument("--query_field")
+        parser.add_argument("--blank_intensity_ratio")
+        parser.add_argument("--drop_name")
+        parser.add_argument("--drop_field")
+        parser.add_argument("--drop_value")
+        parser.add_argument("--drop_others")
+        parser.add_argument("--qaqc_filter")
+        parser.add_argument("--conversion_command")
+        parser.add_argument("--preprocessing_config")
+        parser.add_argument("--new_csv_path")
+        parser.add_argument("--TIC_normalization_percentile")
+        parser.add_argument("--normalize_value")
+        parser.add_argument("--feature_retention_percentile")
+        parser.add_argument("--interpolation_ratio")
+        parser.add_argument("--ms2_dir")
+        parser.add_argument("--report_config")
+        parser.add_argument("--sample_for_ratio")
+        parser.add_argument("--deriv_formula")
+        parser.add_argument("--msp_files")
+        parser.add_argument("--skip_list")
+        parser.add_argument("--add_singletons")
+        parser.add_argument("--extra_asari", default=None)
+        parser.add_argument("--targets")
+        parser.add_argument("--annot_rt_tolerance")
+        parser.add_argument("--annot_mz_tolerance")
+        parser.add_argument("--accept_licenses")
+        parser.add_argument("--scan_experiment", default=False)
+        parser.add_argument("--force", default=False)
+        parser.add_argument("--file_mode", default="link")
+        parser.add_argument("--comprehensive_output", default=False)
+        parser.add_argument("--msp_files_gc")
+        parser.add_argument("--retention_index_standards")
+        parser.add_argument("--auto_drop")
 
         args = parser.parse_args()
         if args.parameters:
-            with open(args.parameters, encoding='utf-8') as param_fh:
+            with open(args.parameters, encoding="utf-8") as param_fh:
                 params.update(json.load(param_fh))
 
         for k, v in args.__dict__.items():
             if v:
                 params[k] = v
-        params['multicores'] = min(mp.cpu_count(), params['multicores'])
+        params["multicores"] = min(mp.cpu_count(), params["multicores"])
 
-        if 'targets' in params:
-            if isinstance(params['targets'], str):
-                params['targets'] = params['targets'].split()
+        if "targets" in params:
+            if isinstance(params["targets"], str):
+                params["targets"] = params["targets"].split()
 
-        for k,v in params.items():
+        for k, v in params.items():
             if isinstance(v, str) and v.endswith(".json"):
-                with open(v, encoding='utf-8') as json_fh:
+                with open(v, encoding="utf-8") as json_fh:
                     params[k] = json.load(json_fh)
-        if 'input' in params and not params['input'].endswith("experiment.json"):
-            params['input'] = os.path.join(os.path.abspath(params['input']), "experiment.json")
+        if "input" in params and not params["input"].endswith("experiment.json"):
+            params["input"] = os.path.join(
+                os.path.abspath(params["input"]), "experiment.json"
+            )
         return params
 
     @staticmethod
     def download_extras(params):
         """
         This method will download the MoNA LC MS/MS library, and the HMDBv5
-        and LMSD in a JMS-compliant format. Currently this downloads from my 
-        google drive (I know not ideal). Will be fixed in the future. 
+        and LMSD in a JMS-compliant format. Currently this downloads from my
+        google drive (I know not ideal). Will be fixed in the future.
 
-        By using this method you agree to the terms and conditions laid 
+        By using this method you agree to the terms and conditions laid
         forth in the licenses for each of those repositories
 
-        :param params: This is the master configuration file generated by 
-                    parsing the command line arguments plus the defaults. 
+        :param params: This is the master configuration file generated by
+                    parsing the command line arguments plus the defaults.
         """
 
-        warning = '''
+        warning = """
         Pcpfm extras are not actively maintained by the developers of pcpfm and are redistributed forms of third party
         publically available tools. Any issues encountered with these extras may or may not be a problem of pcpfm; 
         however, feel free to raise an issue for us to evaluate. 
@@ -244,11 +256,20 @@ class Main():
         
         By downloading these extras you agree to the terms of their licenses. 
 
-        '''
+        """
         print(warning)
 
         accepted_license = False
-        if params['accept_licenses'] in ["True", "TRUE", "Yes", "yes", "T", "Y", "YES", True]:
+        if params["accept_licenses"] in [
+            "True",
+            "TRUE",
+            "Yes",
+            "yes",
+            "T",
+            "Y",
+            "YES",
+            True,
+        ]:
             accepted_license = True
         else:
             user_input = input("Do you accept their license terms (type yes or no)? ")
@@ -257,26 +278,33 @@ class Main():
 
         if accepted_license:
             this_dir = os.path.abspath(os.path.dirname(__file__))
-            download_from_cloud_storage('https://github.com/compomics/ThermoRawFileParser/releases/download/v1.4.4/ThermoRawFileParser1.4.4.zip', 
-                                        os.path.join(this_dir, "annotation_sources/ThermoRawFileParser.zip"))
-            download_from_cloud_storage('https://storage.googleapis.com/pcpfm-data/annotation_sources-20240119T131612Z-001.zip', 
-                                        os.path.join(this_dir, "annotation_sources/ThermoRawFileParser.zip"), use_gdown=True)
-            download_from_cloud_storage('https://mona.fiehnlab.ucdavis.edu/rest/downloads/retrieve/a09f9652-c7bc-48b2-9dd9-0dc4343bb360', 
-                                        os.path.join(this_dir, "annotation_sources/GC_MoNA_EIMS.msp"))
+            download_from_cloud_storage(
+                "https://github.com/compomics/ThermoRawFileParser/releases/download/v1.4.4/ThermoRawFileParser1.4.4.zip",
+                os.path.join(this_dir, "annotation_sources/ThermoRawFileParser.zip"),
+            )
+            download_from_cloud_storage(
+                "https://storage.googleapis.com/pcpfm-data/annotation_sources-20240119T131612Z-001.zip",
+                os.path.join(this_dir, "annotation_sources/ThermoRawFileParser.zip"),
+                use_gdown=True,
+            )
+            download_from_cloud_storage(
+                "https://mona.fiehnlab.ucdavis.edu/rest/downloads/retrieve/a09f9652-c7bc-48b2-9dd9-0dc4343bb360",
+                os.path.join(this_dir, "annotation_sources/GC_MoNA_EIMS.msp"),
+            )
 
     @staticmethod
     def preprocess(params):
         """
         Using the mappings in the preprocessing config, this will alter
-        a provided sequence file and add the extra fields. 
+        a provided sequence file and add the extra fields.
 
-        :param params: This is the master configuration file generated by 
-                    parsing the command line arguments plus the defaults. 
+        :param params: This is the master configuration file generated by
+                    parsing the command line arguments plus the defaults.
         """
-        preprocess_config = params['preprocessing_config']
+        preprocess_config = params["preprocessing_config"]
         params["sequence"] = os.path.abspath(params["sequence"])
-        with open(params['new_csv_path'], 'w+', encoding='utf-8') as out_csv_fh:
-            with open(params['sequence'], encoding='utf-8') as sequence_fh:
+        with open(params["new_csv_path"], "w+", encoding="utf-8") as out_csv_fh:
+            with open(params["sequence"], encoding="utf-8") as sequence_fh:
                 for x, entry in enumerate(csv.DictReader(sequence_fh)):
                     for new_field, _d in preprocess_config["mappings"].items():
                         entry[new_field] = []
@@ -284,7 +312,10 @@ class Main():
                             found = False
                             for substring in _dd["substrings"]:
                                 for field_to_search in _dd["search"]:
-                                    if substring in entry[field_to_search] and found is False:
+                                    if (
+                                        substring in entry[field_to_search]
+                                        and found is False
+                                    ):
                                         found = True
                                         entry[new_field].append(new_value)
                             if found is False:
@@ -294,11 +325,13 @@ class Main():
                     if os.path.exists(params["path_field"]):
                         pass
                     else:
-                        sequence_dir = os.path.dirname(params['sequence'])
+                        sequence_dir = os.path.dirname(params["sequence"])
                         mzml_name = entry[params["name_field"]] + ".mzML"
                         raw_name = entry[params["name_field"]] + ".raw"
                         if os.path.exists(os.path.join(sequence_dir, mzml_name)):
-                            entry["InferredPath"] = os.path.join(sequence_dir, mzml_name)
+                            entry["InferredPath"] = os.path.join(
+                                sequence_dir, mzml_name
+                            )
                         elif os.path.exists(os.path.join(sequence_dir, raw_name)):
                             entry["InferredPath"] = os.path.join(sequence_dir, raw_name)
                     if x == 0:
@@ -310,80 +343,81 @@ class Main():
     def assemble_study(params):
         raise NotImplementedError
 
-
     @staticmethod
     def assemble(params):
         """
-        This is the first command in any pcpfm analysis. Starting with a 
+        This is the first command in any pcpfm analysis. Starting with a
         sequence file, specified by '-s', an output directory by '-o'
-        and a project name specified by '-j', this will create the 
-        experiment directory and initialize the experiment.json. 
+        and a project name specified by '-j', this will create the
+        experiment directory and initialize the experiment.json.
 
-        Additional arguments include the ability to add a filter on 
+        Additional arguments include the ability to add a filter on
         sequence file entries using the '--filter' option and a JSON
         dictionaries.
 
         <<TODO>>
 
-        Additionally, the --name_field, and --path_field options will 
+        Additionally, the --name_field, and --path_field options will
         allow the user to specify what field name should be used for the
-        name and filepath of the acquisitions. Also using --skip_list and 
-        a .txt formatted file containing sample_names to ignore, entries 
-        can be excluded from an analysis. 
-        
-        :param params: This is the master configuration file generated by 
-                    parsing the command line arguments plus the defaults. 
+        name and filepath of the acquisitions. Also using --skip_list and
+        a .txt formatted file containing sample_names to ignore, entries
+        can be excluded from an analysis.
+
+        :param params: This is the master configuration file generated by
+                    parsing the command line arguments plus the defaults.
         """
         experiment = Experiment.Experiment.construct_experiment_from_CSV(
-            os.path.join(os.path.abspath(params['output']), str(params['project'])),
-            params['sequence'],
-            sample_filter=params['filter'],
-            name_field=params['name_field'],
-            path_field=params['path_field'],
-            sample_skip_list_fp=params['skip_list'],
-            file_mode=params['file_mode']
+            os.path.join(os.path.abspath(params["output"]), str(params["project"])),
+            params["sequence"],
+            sample_filter=params["filter"],
+            name_field=params["name_field"],
+            path_field=params["path_field"],
+            sample_skip_list_fp=params["skip_list"],
+            file_mode=params["file_mode"],
         )
         experiment.save()
 
     @staticmethod
     def convert(params):
         """
-        This will convert all .raw files to .mzML using a specified 
-        command. To provide the command, you can either modify the 
-        config file OR pass the command using the --conversion_command. 
-        for this use case, use whatever command will do the conversion but 
-        where the .raw file path would be, substitute with $RAW_PATH and 
-        where the output would go, put $OUT_PATH. 
+        This will convert all .raw files to .mzML using a specified
+        command. To provide the command, you can either modify the
+        config file OR pass the command using the --conversion_command.
+        for this use case, use whatever command will do the conversion but
+        where the .raw file path would be, substitute with $RAW_PATH and
+        where the output would go, put $OUT_PATH.
 
         This requires passing -i with the experiment's path.
 
-        :param params: This is the master configuration file generated by 
-                    parsing the command line arguments plus the defaults. 
+        :param params: This is the master configuration file generated by
+                    parsing the command line arguments plus the defaults.
         """
-        experiment = Experiment.Experiment.load(params['input'])
-        experiment.convert_raw_to_mzML(params['conversion_command'], num_cores=params['multicores'])
+        experiment = Experiment.Experiment.load(params["input"])
+        experiment.convert_raw_to_mzML(
+            params["conversion_command"], num_cores=params["multicores"]
+        )
         experiment.save()
 
     @staticmethod
     def asari(params, gc=False):
         """
         Perform asari on the experiment's acquisitions. They must be have
-        been converted or provided in .mzML format first. 
+        been converted or provided in .mzML format first.
 
-        The command by default assumes a ppm of 5 and the ionization mode 
-        of the experiment will be automatically inferred. If extra 
+        The command by default assumes a ppm of 5 and the ionization mode
+        of the experiment will be automatically inferred. If extra
         arguments are desired for asari, they can be provided using
-        --extra_asari on the command line. 
+        --extra_asari on the command line.
 
         This requires passing -i with the experiment's path.
 
-        :param params: This is the master configuration file generated by 
-                    parsing the command line arguments plus the defaults. 
+        :param params: This is the master configuration file generated by
+                    parsing the command line arguments plus the defaults.
         """
-        experiment = Experiment.Experiment.load(params['input'])
-        asari_command = params['asari_command']
-        if params['extra_asari']:
-            asari_command.extend(params['extra_asari'].split(" "))
+        experiment = Experiment.Experiment.load(params["input"])
+        asari_command = params["asari_command"]
+        if params["extra_asari"]:
+            asari_command.extend(params["extra_asari"].split(" "))
         experiment.asari(asari_command)
         experiment.save()
 
@@ -391,32 +425,34 @@ class Main():
     def asari_gc(params):
         """
         Perform asari on the experiment's acquisitions. They must be have
-        been converted or provided in .mzML format first. 
+        been converted or provided in .mzML format first.
 
-        The command by default assumes a ppm of 5 and the ionization mode 
-        of the experiment will be automatically inferred. If extra 
+        The command by default assumes a ppm of 5 and the ionization mode
+        of the experiment will be automatically inferred. If extra
         arguments are desired for asari, they can be provided using
-        --extra_asari on the command line. 
+        --extra_asari on the command line.
 
         This requires passing -i with the experiment's path.
 
-        :param params: This is the master configuration file generated by 
-                    parsing the command line arguments plus the defaults. 
+        :param params: This is the master configuration file generated by
+                    parsing the command line arguments plus the defaults.
         """
 
         print("Using GC workflow, equivalent to --workflow GC --compress True")
-        experiment = Experiment.Experiment.load(params['input'])
+        experiment = Experiment.Experiment.load(params["input"])
 
         payload = {
-            '--workflow': 'GC',
-            '--compress': 'True',
-            '--retention_index_standards': params.get('retention_index_standards', None),
-            '--GC_Database': params.get('msp_files_gc', None),
+            "--workflow": "GC",
+            "--compress": "True",
+            "--retention_index_standards": params.get(
+                "retention_index_standards", None
+            ),
+            "--GC_Database": params.get("msp_files_gc", None),
         }
-        
-        asari_command = params['asari_command']
-        if params['extra_asari']:
-            asari_command.extend(params['extra_asari'].split(" "))
+
+        asari_command = params["asari_command"]
+        if params["extra_asari"]:
+            asari_command.extend(params["extra_asari"].split(" "))
         for key, value in payload.items():
             asari_command.extend([key, value])
         experiment.asari(asari_command)
@@ -426,31 +462,33 @@ class Main():
     def QAQC(params):
         """
         This will perform various QAQC metrics on the indicated feature
-        table. By default "all" QAQC metrics are performed which are 
-        detailed in the feature table object. 
+        table. By default "all" QAQC metrics are performed which are
+        detailed in the feature table object.
 
-        This requires passing -i with the experiment's path. 
+        This requires passing -i with the experiment's path.
         The feature table on which to perform the procedures must be given
         as well using either --table_moniker or -tm.
 
         TODO: this will be deprecated in the future and performed on lazily
-        either during report generation or qa/qc filtering. 
+        either during report generation or qa/qc filtering.
 
         The fields --color_by, --text_by, --marker_by can specify how
-        to generate the figures this method generates. For each of these 
+        to generate the figures this method generates. For each of these
         commands, a JSON-formatted list of sequence file fields on which
-        to generate the corresponding cosmetic item. These are optional. 
+        to generate the corresponding cosmetic item. These are optional.
 
-        :param params: This is the master configuration file generated by 
-                    parsing the command line arguments plus the defaults. 
+        :param params: This is the master configuration file generated by
+                    parsing the command line arguments plus the defaults.
         """
-        experiment = Experiment.Experiment.load(params['input'])
+        experiment = Experiment.Experiment.load(params["input"])
         experiment.parameters = params["experiment_config"]
-        feature_table = experiment.retrieve_feature_table(params['table_moniker'], True)
-        if params['table_moniker'] not in experiment.qcqa_results:     
-            experiment.qcqa_results[params['table_moniker']] = {}
+        feature_table = experiment.retrieve_feature_table(params["table_moniker"], True)
+        if params["table_moniker"] not in experiment.qcqa_results:
+            experiment.qcqa_results[params["table_moniker"]] = {}
         for qaqc_result in feature_table.QAQC(params):
-            experiment.qcqa_results[params['table_moniker']][qaqc_result["Type"]] = qaqc_result
+            experiment.qcqa_results[params["table_moniker"]][qaqc_result["Type"]] = (
+                qaqc_result
+            )
         experiment.save()
 
     @staticmethod
@@ -459,12 +497,12 @@ class Main():
         Print the list of empirical compounds and feature tables registered
         wiht the experiment object.
 
-        This requires passing -i with the experiment's path. 
+        This requires passing -i with the experiment's path.
 
-        :param params: This is the master configuration file generated by 
-                    parsing the command line arguments plus the defaults. 
+        :param params: This is the master configuration file generated by
+                    parsing the command line arguments plus the defaults.
         """
-        experiment = Experiment.Experiment.load(params['input'])
+        experiment = Experiment.Experiment.load(params["input"])
         experiment.summarize()
 
     @staticmethod
@@ -496,21 +534,23 @@ class Main():
         :param params: This is the master configuration file generated by 
                     parsing the command line arguments plus the defaults. 
         """
-        experiment = Experiment.Experiment.load(params['input'])
+        experiment = Experiment.Experiment.load(params["input"])
         if experiment.ionization_mode == "pos":
-            params['khipu_adducts'] = params['khipu_adducts_pos']
+            params["khipu_adducts"] = params["khipu_adducts_pos"]
         else:
-            params['khipu_adducts'] = params['khipu_adducts_neg']
-        EmpCpds.EmpCpds.construct_from_feature_table(experiment,
-                                                    params['khipu_isotopes'],
-                                                    params['khipu_adducts'],
-                                                    params['khipu_extended_adducts'],
-                                                    params['table_moniker'],
-                                                    params['empCpd_moniker'],
-                                                    params['add_singletons'],
-                                                    params['khipu_rt_tolerance'],
-                                                    params['ppm'],
-                                                    params['khipu_charges'])
+            params["khipu_adducts"] = params["khipu_adducts_neg"]
+        EmpCpds.EmpCpds.construct_from_feature_table(
+            experiment,
+            params["khipu_isotopes"],
+            params["khipu_adducts"],
+            params["khipu_extended_adducts"],
+            params["table_moniker"],
+            params["empCpd_moniker"],
+            params["add_singletons"],
+            params["khipu_rt_tolerance"],
+            params["ppm"],
+            params["khipu_charges"],
+        )
         experiment.save()
 
     @staticmethod
@@ -519,29 +559,30 @@ class Main():
         Print the list of empirical compounds and feature tables registered
         wiht the experiment object.
 
-        - This requires passing -i with the experiment's path. 
+        - This requires passing -i with the experiment's path.
         - This requires passing -tm with the feature table's moniker.
 
-        :param params: This is the master configuration file generated by 
-                    parsing the command line arguments plus the defaults. 
+        :param params: This is the master configuration file generated by
+                    parsing the command line arguments plus the defaults.
         """
-        experiment = Experiment.Experiment.load(params['input'])
-        feature_table = experiment.retrieve_feature_table(params['table_moniker'], True)
-        feature_table.blank_mask(params['blank_value'],
-                                    params['sample_value'],
-                                    params['query_field'],
-                                    float(params['blank_intensity_ratio']),
-                                    params['by_batch'],
-                                    params['batch_blanking_logic'])
-        feature_table.save(params['new_moniker'])
+        experiment = Experiment.Experiment.load(params["input"])
+        feature_table = experiment.retrieve_feature_table(params["table_moniker"], True)
+        feature_table.blank_mask(
+            params["blank_value"],
+            params["sample_value"],
+            params["query_field"],
+            float(params["blank_intensity_ratio"]),
+            params["by_batch"],
+            params["batch_blanking_logic"],
+        )
+        feature_table.save(params["new_moniker"])
 
     @staticmethod
     def reset_cosmetics(params):
-        experiment = Experiment.Experiment.load(params['input'])
+        experiment = Experiment.Experiment.load(params["input"])
         experiment.cosmetics = {}
         experiment.used_cosmetics = {}
         experiment.save()
-
 
     @staticmethod
     def drop_outliers(params):
@@ -551,16 +592,16 @@ class Main():
         By default this is a |Z| > 2.5 filter on the number of features. This Z-score is calculated
         using the median.
 
-        - This requires passing -i with the experiment's path. 
+        - This requires passing -i with the experiment's path.
         - This requires passing -tm with the feature table's moniker.
 
-        :param params: This is the master configuration file generated by 
-                    parsing the command line arguments plus the defaults. 
+        :param params: This is the master configuration file generated by
+                    parsing the command line arguments plus the defaults.
         """
-        experiment = Experiment.Experiment.load(params['input'])
-        feature_table = experiment.retrieve_feature_table(params['table_moniker'], True)
-        feature_table.drop_samples_by_qaqc(params['auto_drop'], False, params=params)
-        feature_table.save(params['new_moniker'])
+        experiment = Experiment.Experiment.load(params["input"])
+        feature_table = experiment.retrieve_feature_table(params["table_moniker"], True)
+        feature_table.drop_samples_by_qaqc(params["auto_drop"], False, params=params)
+        feature_table.save(params["new_moniker"])
 
     @staticmethod
     def drop_samples(params):
@@ -584,109 +625,123 @@ class Main():
         :param params: This is the master configuration file generated by 
                     parsing the command line arguments plus the defaults. 
         """
-        experiment = Experiment.Experiment.load(params['input'])
-        feature_table = experiment.retrieve_feature_table(params['table_moniker'], True)
-        if params['drop_name']:
-            feature_table.drop_sample_by_name(params['drop_name'], params['drop_others'])
-        elif params['filter']:
-            feature_table.drop_samples_by_filter(params['filter'], params['drop_others'])
-        elif params['qaqc_filter']:
-            feature_table.drop_samples_by_qaqc(params['qaqc_filter'], params['drop_others'], params=params)
-        elif params['drop_field'] and params['drop_value']:
-            feature_table.drop_samples_by_field(params['drop_value'], params['drop_field'], params['drop_others'])
-        feature_table.save(params['new_moniker'])
+        experiment = Experiment.Experiment.load(params["input"])
+        feature_table = experiment.retrieve_feature_table(params["table_moniker"], True)
+        if params["drop_name"]:
+            feature_table.drop_sample_by_name(
+                params["drop_name"], params["drop_others"]
+            )
+        elif params["filter"]:
+            feature_table.drop_samples_by_filter(
+                params["filter"], params["drop_others"]
+            )
+        elif params["qaqc_filter"]:
+            feature_table.drop_samples_by_qaqc(
+                params["qaqc_filter"], params["drop_others"], params=params
+            )
+        elif params["drop_field"] and params["drop_value"]:
+            feature_table.drop_samples_by_field(
+                params["drop_value"], params["drop_field"], params["drop_others"]
+            )
+        feature_table.save(params["new_moniker"])
 
     @staticmethod
     def finish(params):
         """
-        This command is a no-op command for marking the end of an 
-        anlysis in the command history. 
+        This command is a no-op command for marking the end of an
+        anlysis in the command history.
 
-        This requires passing -i with the experiment's path. 
+        This requires passing -i with the experiment's path.
 
-        :param params: This is the master configuration file generated by 
-                    parsing the command line arguments plus the defaults. 
+        :param params: This is the master configuration file generated by
+                    parsing the command line arguments plus the defaults.
         """
-        experiment = Experiment.Experiment.load(params['input'])
+        experiment = Experiment.Experiment.load(params["input"])
         experiment.save()
 
     @staticmethod
     def normalize(params):
         """
-        Normalize a feature table based on the TIC of the features 
-        present in over a certain percentile of samples. 
+        Normalize a feature table based on the TIC of the features
+        present in over a certain percentile of samples.
 
         - --TIC_normalization_percentile defines this cutoff
-        - --by_batch designates the field to group into batches, if 
+        - --by_batch designates the field to group into batches, if
            provided, normalization will be done within batches first
-        - --normalize_value can be 'mean' or 'median', this will be the 
+        - --normalize_value can be 'mean' or 'median', this will be the
            value to which the TICs will be normalized
 
-        - This requires passing -i with the experiment's path. 
+        - This requires passing -i with the experiment's path.
         - This requires passing -tm with the feature table's moniker.
         - This requires passing -nm with the new feature table's moniker
 
-        :param params: This is the master configuration file generated by 
-                    parsing the command line arguments plus the defaults. 
+        :param params: This is the master configuration file generated by
+                    parsing the command line arguments plus the defaults.
         """
-        experiment = Experiment.Experiment.load(params['input'])
-        feature_table = experiment.retrieve_feature_table(params['table_moniker'], True)
+        experiment = Experiment.Experiment.load(params["input"])
+        feature_table = experiment.retrieve_feature_table(params["table_moniker"], True)
         if params["TIC_normalization_percentile"]:
-            feature_table.TIC_normalize(float(params["TIC_normalization_percentile"]),
-                                        params["by_batch"],
-                                        params["normalize_value"])
-        feature_table.save(params['new_moniker'])
+            feature_table.TIC_normalize(
+                float(params["TIC_normalization_percentile"]),
+                params["by_batch"],
+                params["normalize_value"],
+            )
+        feature_table.save(params["new_moniker"])
 
     @staticmethod
     def drop_missing_features(params):
         """
-        Drop samples below a given percentile of inclusion. 
+        Drop samples below a given percentile of inclusion.
 
         - --feature_retention_percentile defines this cutoff
-        - --by_batch designates the field to group into batches, if 
+        - --by_batch designates the field to group into batches, if
            provided, the percentile is caluclated per batch first
-        - --feature_drop_logic can be "or" or "and" and specifies how 
+        - --feature_drop_logic can be "or" or "and" and specifies how
            handle the various batches. For example, if "or", a feature
            will be dropped if it is below the cutoff in any batch.
 
-        - This requires passing -i with the experiment's path. 
+        - This requires passing -i with the experiment's path.
         - This requires passing -tm with the feature table's moniker.
         - This requires passing -nm with the new feature table's moniker.
 
-        :param params: This is the master configuration file generated by 
-                    parsing the command line arguments plus the defaults. 
+        :param params: This is the master configuration file generated by
+                    parsing the command line arguments plus the defaults.
         """
-        experiment = Experiment.Experiment.load(params['input'])
-        feature_table = experiment.retrieve_feature_table(params['table_moniker'], True)
-        feature_table.drop_missing_features(params["by_batch"],
-                                            float(params["feature_retention_percentile"]),
-                                            params["feature_drop_logic"])
-        feature_table.save(params['new_moniker'])
+        experiment = Experiment.Experiment.load(params["input"])
+        feature_table = experiment.retrieve_feature_table(params["table_moniker"], True)
+        feature_table.drop_missing_features(
+            params["by_batch"],
+            float(params["feature_retention_percentile"]),
+            params["feature_drop_logic"],
+        )
+        feature_table.save(params["new_moniker"])
 
     @staticmethod
     def impute(params):
         """
         Replace remaining missing values with a value to aid statistics
-        
-        - --interpolation_ratio this value specifies what to multiply the 
+
+        - --interpolation_ratio this value specifies what to multiply the
           value generated by the interpolate_method before replacement
         - --interpolate_method currently limited to only min
-        - --by_batch this field specifies what field to group samples by 
+        - --by_batch this field specifies what field to group samples by
           and interpolates within each group (probably a bad idea)
 
-        - This requires passing -i with the experiment's path. 
+        - This requires passing -i with the experiment's path.
         - This requires passing -tm with the feature table's moniker.
         - This requires passing -nm with the new feature table's moniker.
 
-        :param params: This is the master configuration file generated by 
-                    parsing the command line arguments plus the defaults. 
+        :param params: This is the master configuration file generated by
+                    parsing the command line arguments plus the defaults.
         """
-        experiment = Experiment.Experiment.load(params['input'])
-        feature_table = experiment.retrieve_feature_table(params['table_moniker'], True)
-        feature_table.impute_missing_features(float(params['interpolation_ratio']),
-                                                    params['by_batch'],
-                                                    params['interpolate_method'])
-        feature_table.save(params['new_moniker'])
+        experiment = Experiment.Experiment.load(params["input"])
+        feature_table = experiment.retrieve_feature_table(params["table_moniker"], True)
+        feature_table.impute_missing_features(
+            float(params["interpolation_ratio"]),
+            params["by_batch"],
+            params["interpolate_method"],
+        )
+        feature_table.save(params["new_moniker"])
 
     @staticmethod
     def batch_correct(params):
@@ -694,19 +749,19 @@ class Main():
         Use pyCombat to correct for batch effects using the specified batch
         identifier.
 
-        - This requires passing -i with the experiment's path. 
+        - This requires passing -i with the experiment's path.
         - This requires passing -tm with the feature table's moniker.
         - This requires passing -nm with the new feature table's moniker.
-        - This requires passing --by_batch with the field specifying the 
+        - This requires passing --by_batch with the field specifying the
             batch on which to correct
 
-        :param params: This is the master configuration file generated by 
-                    parsing the command line arguments plus the defaults. 
+        :param params: This is the master configuration file generated by
+                    parsing the command line arguments plus the defaults.
         """
-        experiment = Experiment.Experiment.load(params['input'])
-        feature_table = experiment.retrieve_feature_table(params['table_moniker'], True)
-        feature_table.batch_correct(params['by_batch'])
-        feature_table.save(params['new_moniker'])
+        experiment = Experiment.Experiment.load(params["input"])
+        feature_table = experiment.retrieve_feature_table(params["table_moniker"], True)
+        feature_table.batch_correct(params["by_batch"])
+        feature_table.save(params["new_moniker"])
 
     @staticmethod
     def delete(params):
@@ -724,11 +779,11 @@ class Main():
         :param params: This is the master configuration file generated by 
                     parsing the command line arguments plus the defaults. 
         """
-        experiment = Experiment.Experiment.load(params['input'])
+        experiment = Experiment.Experiment.load(params["input"])
         if params["table_moniker"]:
-            experiment.delete_feature_table(params['table_moniker'])
-        elif params['empCpd_moniker']:
-            experiment.delete_empCpds(params['empCpd_moniker'])
+            experiment.delete_feature_table(params["table_moniker"])
+        elif params["empCpd_moniker"]:
+            experiment.delete_empCpds(params["empCpd_moniker"])
 
     @staticmethod
     def log_transform(params):
@@ -737,19 +792,18 @@ class Main():
 
         --log_transform_mode can be log10 or log2
 
-        - This requires passing -i with the experiment's path. 
+        - This requires passing -i with the experiment's path.
         - This requires passing -tm with the table's moniker to transform
         - This requires passing -nm with the new feature table's moniker
 
-        :param params: This is the master configuration file generated by 
-                    parsing the command line arguments plus the defaults. 
+        :param params: This is the master configuration file generated by
+                    parsing the command line arguments plus the defaults.
         """
-        experiment = Experiment.Experiment.load(params['input'])
-        feature_table = experiment.retrieve_feature_table(params['table_moniker'], True)
-        feature_table.log_transform(params['log_transform_mode'])
+        experiment = Experiment.Experiment.load(params["input"])
+        feature_table = experiment.retrieve_feature_table(params["table_moniker"], True)
+        feature_table.log_transform(params["log_transform_mode"])
         experiment.log_transformed_feature_tables.append(params["new_moniker"])
         feature_table.save(params["new_moniker"])
-
 
     @staticmethod
     def l4_annotate(params):
@@ -774,11 +828,11 @@ class Main():
                     parsing the command line arguments plus the defaults. 
         """
 
-        experiment = Experiment.Experiment.load(params['input'])
-        if 'empCpd_moniker' in params:
-            empCpd = experiment.retrieve_empCpds(params['empCpd_moniker'], True)
-            empCpd.l4_annotate(params['targets'], float(params['annot_rt_tolerance']))
-            empCpd.save(params['new_moniker'])
+        experiment = Experiment.Experiment.load(params["input"])
+        if "empCpd_moniker" in params:
+            empCpd = experiment.retrieve_empCpds(params["empCpd_moniker"], True)
+            empCpd.l4_annotate(params["targets"], float(params["annot_rt_tolerance"]))
+            empCpd.save(params["new_moniker"])
 
     @staticmethod
     def l2_annotate(params):
@@ -791,32 +845,32 @@ class Main():
         - **--annot_rt_tolerance**: Time cutoff, in seconds, for the precursor ion search, default = 30sec.
         - **--ms2_similarity_metric**: Name of any matchms method for comparing MS2 spectra, default = CosineHungarian.
         - **--ms2_min_peak**: Minimum number of matching peaks required for an MS2 match, default = 3.
-        
+
         ..
 
-        - This requires passing -i with the experiment's path. 
-        - This requires passing -tm with the table's moniker to annotate or 
+        - This requires passing -i with the experiment's path.
+        - This requires passing -tm with the table's moniker to annotate or
         - This requires passing -em with the empCpd's moniker to annotate
         - This requires passing -nm with the new moniker for the table or empcpd list.
 
-        :param params: This is the master configuration file generated by 
+        :param params: This is the master configuration file generated by
                     parsing the command line arguments plus the defaults.
         """
-        experiment = Experiment.Experiment.load(params['input'])
-        if 'msp_files' in params:
-            msp_file = params['msp_files']
+        experiment = Experiment.Experiment.load(params["input"])
+        if "msp_files" in params:
+            msp_file = params["msp_files"]
             if isinstance(msp_file, str):
                 if msp_file.endswith(".json"):
-                    with open(msp_file, encoding='utf-8') as msp_fh:
+                    with open(msp_file, encoding="utf-8") as msp_fh:
                         msp_file = json.load(msp_fh)
                 else:
                     msp_file = [msp_file]
         elif experiment.ionization_mode == "pos":
-            msp_file = params['msp_files_pos']
+            msp_file = params["msp_files_pos"]
         elif experiment.ionization_mode == "neg":
-            msp_file = params['msp_files_neg']
-        if 'empCpd_moniker' in params:
-            empCpd = experiment.retrieve_empCpds(params['empCpd_moniker'], True)
+            msp_file = params["msp_files_neg"]
+        if "empCpd_moniker" in params:
+            empCpd = experiment.retrieve_empCpds(params["empCpd_moniker"], True)
             empCpd.l2_annotate(
                 msp_file,
                 params["annot_mz_tolerance"],
@@ -845,90 +899,94 @@ class Main():
 
         :param params: This is the master configuration file generated by parsing the command line arguments plus the defaults.
         """
-        experiment = Experiment.Experiment.load(params['input'])
-        if 'empCpd_moniker' in params:
-            empCpd = experiment.retrieve_empCpds(params['empCpd_moniker'], True)
-            empCpd.l1b_annotate(params['targets'],
-                                float(params['annot_rt_tolerance']), 
-                                float(params['annot_mz_tolerance'])
-                                )
-            empCpd.save(params['new_moniker'])
+        experiment = Experiment.Experiment.load(params["input"])
+        if "empCpd_moniker" in params:
+            empCpd = experiment.retrieve_empCpds(params["empCpd_moniker"], True)
+            empCpd.l1b_annotate(
+                params["targets"],
+                float(params["annot_rt_tolerance"]),
+                float(params["annot_mz_tolerance"]),
+            )
+            empCpd.save(params["new_moniker"])
 
     @staticmethod
     def l1a_annotate(params):
         """
         This will generate level 1 annotations on a empcpd list using
-        a csv file(s) with compound names, retention times and m/z 
-        values. 
+        a csv file(s) with compound names, retention times and m/z
+        values.
 
-        --targets are a list of csv filepaths with mz, retention 
+        --targets are a list of csv filepaths with mz, retention
         times, compound names with column names, "mz", "rtime",
         "CompoundName"
-        --annot_mz_tolerance this is the ppm cutoff for the precursor 
+        --annot_mz_tolerance this is the ppm cutoff for the precursor
             ion search
         --annot_rt_tolerance this is the rtime cutoff, in sec, for
             the precursor ion search
 
         This requires passing -em with the empCpd's moniker to annotate
-        This requires passing -nm with the new moniker for the table or 
+        This requires passing -nm with the new moniker for the table or
             empcpd list.
 
-        :param params: This is the master configuration file generated by 
-        parsing the command line arguments plus the defaults. 
+        :param params: This is the master configuration file generated by
+        parsing the command line arguments plus the defaults.
         """
-        experiment = Experiment.Experiment.load(params['input'])
-        if 'empCpd_moniker' in params:
-            empCpd = experiment.retrieve_empCpds(params['empCpd_moniker'], True)
-            empCpd.l1a_annotate(params['targets'],
-                                float(params['annot_rt_tolerance']), 
-                                float(params['annot_mz_tolerance']),
-                                )
-            empCpd.save(params['new_moniker'])
+        experiment = Experiment.Experiment.load(params["input"])
+        if "empCpd_moniker" in params:
+            empCpd = experiment.retrieve_empCpds(params["empCpd_moniker"], True)
+            empCpd.l1a_annotate(
+                params["targets"],
+                float(params["annot_rt_tolerance"]),
+                float(params["annot_mz_tolerance"]),
+            )
+            empCpd.save(params["new_moniker"])
 
     @staticmethod
     def report(params):
         """
-        This will generate a pdf report using a JSON template 
+        This will generate a pdf report using a JSON template
 
         - **--report_config** will override the default template
 
-        - This requires passing -i with the experiment's path. 
+        - This requires passing -i with the experiment's path.
 
-        :param params: This is the master configuration file generated by 
-                    parsing the command line arguments plus the defaults. 
+        :param params: This is the master configuration file generated by
+                    parsing the command line arguments plus the defaults.
         """
         Main.reset_cosmetics(params)
-        experiment = Experiment.Experiment.load(params['input'])
+        experiment = Experiment.Experiment.load(params["input"])
         Report.Report(experiment, params)
 
     @staticmethod
     def map_ms2(params):
         """
-        This maps MS2 spectra to the empCompounds based on rt and mz similarity. 
+        This maps MS2 spectra to the empCompounds based on rt and mz similarity.
 
         Once mapped, they can be annotated using MS2 similarity via l2_annotate and l1a_annotate.
 
-        --annot_mz_tolerance this is the ppm cutoff for the precursor 
+        --annot_mz_tolerance this is the ppm cutoff for the precursor
             ion search, default is 5 ppm
         --annot_rt_tolerance this is the rtime cutoff, in sec, for
             the precursor ion search, default is 30 sec
 
-        This will scan for all MS2 spectra in the experiment. Additional MS2, from AcquireX for 
+        This will scan for all MS2 spectra in the experiment. Additional MS2, from AcquireX for
         example, can be added by specifying the path to them using --ms2_dir.
-        
-        - This requires passing -i with the experiment's path. 
+
+        - This requires passing -i with the experiment's path.
         - This requires passing -em with the empCpd's moniker to annotate
         - This requires passing -nm with the new moniker for the empcpd list.
 
-        :param params: This is the master configuration file generated by 
-                    parsing the command line arguments plus the defaults. 
+        :param params: This is the master configuration file generated by
+                    parsing the command line arguments plus the defaults.
         """
-        experiment = Experiment.Experiment.load(params['input'])
-        empCpds = experiment.retrieve_empCpds(params['empCpd_moniker'], True)
-        empCpds.map_ms2(float(params['annot_rt_tolerance']), 
-                        float(params['annot_mz_tolerance']), 
-                        ms2_files=params['ms2_dir'],
-                        scan_experiment=params['scan_experiment'])
+        experiment = Experiment.Experiment.load(params["input"])
+        empCpds = experiment.retrieve_empCpds(params["empCpd_moniker"], True)
+        empCpds.map_ms2(
+            float(params["annot_rt_tolerance"]),
+            float(params["annot_mz_tolerance"]),
+            ms2_files=params["ms2_dir"],
+            scan_experiment=params["scan_experiment"],
+        )
         empCpds.save(params["new_moniker"])
 
     @staticmethod
@@ -937,24 +995,28 @@ class Main():
         This command generates the three table output for downstream
         analysis. This includes a feature table, an annotation table,
         and finally the sample metadata. All results are stored in the
-        results subdirectory according to the specified moniker. 
+        results subdirectory according to the specified moniker.
 
         - This requires passing -i with the experiment's path.
         - This requires passing -tm for the table moniker to include
         - This requires passing -em for the empcpd moniker to include
-        - This requires passing -nm for the new moniker to save 
-            generated results using. 
+        - This requires passing -nm for the new moniker to save
+            generated results using.
 
         If you want to have all the feature information in the annotation
         table, please add the following:
 
         --comprehensive_output true
 
-        :param params: This is the master configuration file generated by 
-                    parsing the command line arguments plus the defaults. 
+        :param params: This is the master configuration file generated by
+                    parsing the command line arguments plus the defaults.
         """
-        experiment = Experiment.Experiment.load(params['input'])
-        experiment.generate_output(params['empCpd_moniker'], params['table_moniker'], params['comprehensive_output'])
+        experiment = Experiment.Experiment.load(params["input"])
+        experiment.generate_output(
+            params["empCpd_moniker"],
+            params["table_moniker"],
+            params["comprehensive_output"],
+        )
 
     @staticmethod
     def reset(params):
@@ -962,15 +1024,15 @@ class Main():
         This command resets the experiment object back to when asari was
         ran. This removes all user-generated monikered entities, including
         feature tables and empirical compounds. This removes any qcqa results
-        that were generated along with any qaqc figures. 
+        that were generated along with any qaqc figures.
 
         This is useful if you want to restart an analysis but you do not want
-        to rerun asari, reconvert the acquisitions, or recreate the experiment. 
+        to rerun asari, reconvert the acquisitions, or recreate the experiment.
 
         This action is irreversible
 
             - This requires passing -i with the experiment's path.
-            - If passed, --force, will skip the user confirmation 
+            - If passed, --force, will skip the user confirmation
         """
 
         warning = """
@@ -988,15 +1050,15 @@ class Main():
 
         """
 
-        if not params['force']:
+        if not params["force"]:
             print(warning)
             consent = input()
-            if consent not in {'yes', 'YES', 'y', 'Y'}:
+            if consent not in {"yes", "YES", "y", "Y"}:
                 print("Cancelling reset!")
                 return
-        experiment = Experiment.Experiment.load(params['input'])
-        experiment.delete_feature_table('*')
-        experiment.delete_empCpds('*')
+        experiment = Experiment.Experiment.load(params["input"])
+        experiment.delete_feature_table("*")
+        experiment.delete_empCpds("*")
         experiment.qaqc_figs = None
         experiment.qcqa_results = None
         experiment.log_transformed_feature_tables = None
@@ -1007,12 +1069,11 @@ class Main():
     @staticmethod
     def __update_metadata(params):
         raise NotImplementedError
-        experiment = Experiment.Experiment.load(params['input'])
+        experiment = Experiment.Experiment.load(params["input"])
         for acquisition in experiment.acquisitions:
             if "Process_Blank" in acquisition.source_filepath:
-                acquisition.metadata_tags['Sample Type'] = "Process_Blank"
+                acquisition.metadata_tags["Sample Type"] = "Process_Blank"
         experiment.save()
-
 
 
 def main():
@@ -1022,32 +1083,35 @@ def main():
     params = Main.process_params()
 
     print("Attempting: ", params["subcommand"])
-    if params['subcommand'] not in dir(Main):
-        print(params['subcommand'] + " is not a valid subcommand")
+    if params["subcommand"] not in dir(Main):
+        print(params["subcommand"] + " is not a valid subcommand")
         print("valid commands include:")
         for method in dir(Main):
-            if not method.startswith('__'):
+            if not method.startswith("__"):
                 print("\t", method)
     else:
-        function = getattr(Main, params['subcommand'])
+        function = getattr(Main, params["subcommand"])
         try:
             function(params)
             print("Succesfully executed: ", params["subcommand"])
         except Exception as e:
             import traceback
-            print("Error executing: " + params['subcommand'])
+
+            print("Error executing: " + params["subcommand"])
             print(function.__doc__)
             print("Exception: ", e)
             print("Traceback:")
             print(traceback.format_exc())
 
+
 def CLI():
-    '''
-    This function is called when 'pcpfm' is called in the terminal. 
+    """
+    This function is called when 'pcpfm' is called in the terminal.
 
     Simply a wrapper around main()
-    '''
+    """
     main()
 
-if __name__ == '__main__':        
+
+if __name__ == "__main__":
     main()

--- a/pcpfm/utils.py
+++ b/pcpfm/utils.py
@@ -2,6 +2,7 @@
 Misc helper functions.
 
 """
+
 import os
 import shutil
 import sys
@@ -14,12 +15,13 @@ from mass2chem.formula import calculate_formula_mass
 from matchms.Spectrum import Spectrum
 from .MSnSpectrum import MS2Spectrum
 
+
 def flatten_nested_dicts(nested_dicts):
     """
     For nested dictionaries, i.e., where the value for a key in a dictionary is a dictionary
-    return a flat, dictionary where the nested keys become top level keys. 
+    return a flat, dictionary where the nested keys become top level keys.
 
-    If the same key is used at different levels, the one encountered last will be the 
+    If the same key is used at different levels, the one encountered last will be the
     top level key, value pair.
 
     Args:
@@ -27,7 +29,7 @@ def flatten_nested_dicts(nested_dicts):
 
     Returns:
         dict: flattened dict
-    """    
+    """
     _d = {}
     for k, v in nested_dicts.items():
         if not isinstance(v, dict):
@@ -41,7 +43,7 @@ def extract_CD_csv(
     cd_csvs, ionization_mode, min_peaks=1, precursor_to_use="Confirmed", lazy=True
 ):
     """
-    For a list of compound discover (CD) CSV libraries, read them into a form that is 
+    For a list of compound discover (CD) CSV libraries, read them into a form that is
     usable for level1a annotation.
 
     In lazy mode, this yields the library entries, else a list of them is return.
@@ -151,12 +153,12 @@ def get_similarity_method(method_name):
 
 def lazy_extract_ms2_spectra(ms2_files, mz_tree=None):
     """
-    This method takes a list of ms2 files and yields the MS2 spectrum 
-    for each entry. 
+    This method takes a list of ms2 files and yields the MS2 spectrum
+    for each entry.
 
     Args:
         ms2_files (list): list of ms2_files, can be any format matchms supports.
-        mz_tree (interval_tree, optional): interval tree of precursor mzs, if provided, only 
+        mz_tree (interval_tree, optional): interval tree of precursor mzs, if provided, only
         spectra whose precuror matches the tree will be returned. Defaults to None.
 
     Yields:
@@ -197,8 +199,8 @@ def process_ms2_spectrum(
     :return: dictionary summarize MS2 spectrum.
     """
     try:
-        identifiers = {k: v for k,v in spectrum.metadata.items()}
-    except:
+        identifiers = {k: v for k, v in spectrum.metadata.items()}
+    except BaseException:
         identifiers = {}
 
     if not skip_meta:
@@ -214,7 +216,7 @@ def process_ms2_spectrum(
             return None
         try:
             spectrum.set("retention_time", spectrum.metadata["scan_start_time"][0] * 60)
-        except:
+        except BaseException:
             pass
 
         spec_id = []
@@ -228,7 +230,9 @@ def process_ms2_spectrum(
         spectrum = MS2Spectrum(
             spec_id=spec_id,
             precursor_mz=float(spectrum.get("precursor_mz")),
-            precursor_rt=float(spectrum.get("retention_time")) if spectrum.get("retention_time") else None,
+            precursor_rt=float(spectrum.get("retention_time"))
+            if spectrum.get("retention_time")
+            else None,
             list_mz=[],
             list_intensity=[],
             matchms_spectrum=spectrum,
@@ -236,7 +240,7 @@ def process_ms2_spectrum(
             instrument="Unknown",
             collision_energy="Unknown",
             compound_name=reference_id,
-            identifiers=identifiers
+            identifiers=identifiers,
         )
     else:
         spec_id = []
@@ -268,7 +272,7 @@ def process_ms2_spectrum(
             instrument="Unknown",
             collision_energy="Unknown",
             compound_name=reference_id,
-            identifiers=identifiers
+            identifiers=identifiers,
         )
 
     return spectrum
@@ -335,23 +339,22 @@ descriptive_stat_modes = {
     "mean": np.mean,
 }
 
-log_modes = {
-    "log2": np.log2, 
-    "log10": np.log10
-    }
+log_modes = {"log2": np.log2, "log10": np.log10}
+
 
 def delete_dir_or_file(to_delete):
     try:
         shutil.rmtree(to_delete)
-    except:
+    except BaseException:
         try:
             os.remove(to_delete)
-        except:
+        except BaseException:
             "Unable to delete: " + to_delete
+
 
 file_operations = {
     "link": os.link,
     "copy": shutil.copy,
     "move": shutil.move,
-    "delete": delete_dir_or_file
+    "delete": delete_dir_or_file,
 }


### PR DESCRIPTION
Hello,

I have formatted the codebase with ruff default rules to enforce a uniform style.

Also, I have changed bare except clauses with `except BaseException` to capture all exceptions and get rid of linter warnings.